### PR TITLE
Restore "Fix Borders = 0"

### DIFF
--- a/data/Mafia.WidescreenFix/scripts/Mafia.WidescreenFix.ini
+++ b/data/Mafia.WidescreenFix/scripts/Mafia.WidescreenFix.ini
@@ -4,7 +4,7 @@ FOV Hor+ = 1
 # Option will fix HUD scaling, 1 - 4/3 centered hud, 2 - widescreen hud.
 Fix HUD = 2
 # Option will fix black borders scaling during cutscenes.
-Fix Borders = 1
+Fix Borders = 0
 # Option will fix map scaling. 1 - 4/3 centered, 2 - wide.
 Fix Map = 2
 # Option will fix text scaling.


### PR DESCRIPTION
**Fix Borders = 0** removes the black borders in cutscenes and is default option in the original fix.