### PR TITLE
Update dgVoodoo password

### DIFF
--- a/data/KnightRider.WidescreenFix/scripts/modupdater.ini
+++ b/data/KnightRider.WidescreenFix/scripts/modupdater.ini
@@ -3,11 +3,11 @@ DDraw.dll = https://node-js-geturl.herokuapp.com/?url=(http://dege.freeweb.hu/dg
 D3DImm.dll = https://node-js-geturl.herokuapp.com/?url=(http://dege.freeweb.hu/dgVoodoo2/dgVoodoo2.html)&selector=(a[href*=dgVoodoo])
 
 [DDraw.dll]
-Password = dege
+Password = shitgoogle
 ExtractSingleFile
 PlaceToRoot
 
 [D3DImm.dll]
-Password = dege
+Password = shitgoogle
 ExtractSingleFile
 PlaceToRoot

--- a/data/KnightRider2.WidescreenFix/scripts/modupdater.ini
+++ b/data/KnightRider2.WidescreenFix/scripts/modupdater.ini
@@ -3,11 +3,11 @@ DDraw.dll = https://node-js-geturl.herokuapp.com/?url=(http://dege.freeweb.hu/dg
 D3DImm.dll = https://node-js-geturl.herokuapp.com/?url=(http://dege.freeweb.hu/dgVoodoo2/dgVoodoo2.html)&selector=(a[href*=dgVoodoo])
 
 [DDraw.dll]
-Password = dege
+Password = shitgoogle
 ExtractSingleFile
 PlaceToRoot
 
 [D3DImm.dll]
-Password = dege
+Password = shitgoogle
 ExtractSingleFile
 PlaceToRoot

--- a/data/SplinterCell.WidescreenFix/system/scripts/modupdater.ini
+++ b/data/SplinterCell.WidescreenFix/system/scripts/modupdater.ini
@@ -2,6 +2,6 @@
 d3d8.dll = https://node-js-geturl.herokuapp.com/?url=(http://dege.freeweb.hu/dgVoodoo2/dgVoodoo2.html)&selector=(a[href*=dgVoodoo])
 
 [d3d8.dll]
-Password = dege
+Password = shitgoogle
 ExtractSingleFile
 PlaceToRoot

--- a/data/SplinterCellPandoraTomorrow.WidescreenFix/offline/system/scripts/modupdater.ini
+++ b/data/SplinterCellPandoraTomorrow.WidescreenFix/offline/system/scripts/modupdater.ini
@@ -2,6 +2,6 @@
 d3d8.dll = https://node-js-geturl.herokuapp.com/?url=(http://dege.freeweb.hu/dgVoodoo2/dgVoodoo2.html)&selector=(a[href*=dgVoodoo])
 
 [d3d8.dll]
-Password = dege
+Password = shitgoogle
 ExtractSingleFile
 PlaceToRoot


### PR DESCRIPTION
The password for the archives available on http://dege.freeweb.hu/dgVoodoo2/dgVoodoo2.html has been update to `shitgoogle` (from `dege`).