### PR TITLE
[NFSMW] [NFSPS] [SH3] updates, bug fixes, shadow improvements

### DIFF
--- a/data/NFSMostWanted.WidescreenFix/scripts/NFSMostWanted.WidescreenFix.ini
+++ b/data/NFSMostWanted.WidescreenFix/scripts/NFSMostWanted.WidescreenFix.ini
@@ -10,6 +10,7 @@ FMVWidescreenMode = 1 // FMVs will appear in fullscreen.
 [MISC]
 ShadowsRes = 1024 // Controls the resolution of dynamic shadows and enables them for Intel GPUs.
 ShadowsFix = 1 // Dynamic shadows will no longer disappear when going into tunnels, under bridges, etc.
+ImproveShadowLOD = 0 // Increases the level of detail of dynamic shadows.
 RearviewMirrorFix = 1 // Enables rearview mirror for all camera views.
 CustomUserFilesDirectoryInGameDir = 0 // User files will be stored in a specified directory (for example: "save"). Use 0 to disable.
 WriteSettingsToFile = 0 // All registry settings will be saved to "settings.ini" in your profile folder. You must input your CD key and langauge in "settings.ini" when this option is enabled.

--- a/data/SilentHill3.WidescreenFix/scripts/SilentHill3.WidescreenFix.ini
+++ b/data/SilentHill3.WidescreenFix/scripts/SilentHill3.WidescreenFix.ini
@@ -14,7 +14,7 @@ PixelationFix = 1 // Subtracts 0.5 from render resolution to fix transition bug.
 StatusScreenRes = 512 // Controls resolution of status screen image.
 ShadowsRes = 1024 // Controls resolution of dynamic shadows.
 DOFRes = 1024 // Controls resolution of depth of field and other blur effects.
-FrameRateFluctuationFix = 0 // Framerate won't drop to 30fps, but user must be capable of maintaining 60fps.
+FrameRateFluctuationFix = 1 // Prevents the framerate from jumping between 60 FPS and 30 FPS. (1 = 60 FPS | 2 = 30 FPS)
 ReduceCutsceneFOV = 0 // Cutscenes will use vert- scaling to hide off-screen characters.
 SH2Reference = 1 // Enables several SH2 references for new saves. A feature from sh3proxy.
 FogComplexity = 75 // The higher the value, the more detailed the fog appears. 25 = original value.

--- a/source/NFSMostWanted.WidescreenFix/dllmain.cpp
+++ b/source/NFSMostWanted.WidescreenFix/dllmain.cpp
@@ -21,9 +21,10 @@ void Init()
     bool bFixFOV = iniReader.ReadInteger("MAIN", "FixFOV", 1) != 0;
     bool bHudWidescreenMode = iniReader.ReadInteger("MAIN", "HudWidescreenMode", 1) == 1;
     bool bFMVWidescreenMode = iniReader.ReadInteger("MAIN", "FMVWidescreenMode", 1) == 1;
-    int nScaling = iniReader.ReadInteger("MAIN", "Scaling", 2);
+    int nScaling = iniReader.ReadInteger("MAIN", "Scaling", 1);
     int ShadowsRes = iniReader.ReadInteger("MISC", "ShadowsRes", 1024);
-    bool bShadowsFix = iniReader.ReadInteger("MISC", "ShadowsFix", 1) == 1;
+    bool bShadowsFix = iniReader.ReadInteger("MISC", "ShadowsFix", 1) != 0;
+    bool bImproveShadowLOD = iniReader.ReadInteger("MISC", "ImproveShadowLOD", 0) != 0;
     bool bRearviewMirrorFix = iniReader.ReadInteger("MISC", "RearviewMirrorFix", 1) == 1;
     static auto szCustomUserFilesDirectoryInGameDir = iniReader.ReadString("MISC", "CustomUserFilesDirectoryInGameDir", "");
     bool bWriteSettingsToFile = iniReader.ReadInteger("MISC", "WriteSettingsToFile", 1) != 0;
@@ -135,6 +136,22 @@ void Init()
             uint32_t* dword__93D898 = hook::pattern(pattern_str(to_bytes(dword_93D898))).count(1).get(0).get<uint32_t>(0);
             injector::WriteMemory(dword__93D898, dword_8F1CA0, true);
         }
+
+        // solves shadow acne problem for resolutions greater than 4096
+        if (ShadowsRes > 4096)
+        {
+            static float ShadowBias = (ShadowsRes / 4096.0f) * 4.0f;
+            uint32_t* dword_6E5509 = hook::pattern("8B 15 ? ? ? ? A1 ? ? ? ? 8B 08 52 68").count(1).get(0).get<uint32_t>(2);
+            injector::WriteMemory(dword_6E5509, &ShadowBias, true);
+        }
+    }
+
+    if (bImproveShadowLOD)
+    {
+        uint32_t* dword_6E5174 = hook::pattern("68 ? ? ? ? EB ? A1 ? ? ? ? 0D").count(1).get(0).get<uint32_t>(1);
+        injector::WriteMemory(dword_6E5174, 0x00000000, true);
+        uint32_t* dword_6BFFA2 = hook::pattern("68 ? ? ? ? 50 41 68").count(2).get(1).get<uint32_t>(1);
+        injector::WriteMemory(dword_6BFFA2, 0x00006102, true);
     }
 
     //HUD

--- a/source/NFSProStreet.GenericFix/dllmain.cpp
+++ b/source/NFSProStreet.GenericFix/dllmain.cpp
@@ -157,7 +157,7 @@ void Init()
 
 
     bool bFixHUD = iniReader.ReadInteger("MISC", "FixHUD", 1) != 0;
-    bool bSkipIntro = iniReader.ReadInteger("MISC", "SkipIntro", 1) != 0;
+    bool bSkipIntro = iniReader.ReadInteger("MISC", "SkipIntro", 0) != 0;
     static int32_t nWindowedMode = iniReader.ReadInteger("MISC", "WindowedMode", 0);
     static int32_t nImproveGamepadSupport = iniReader.ReadInteger("MISC", "ImproveGamepadSupport", 0);
     static float fLeftStickDeadzone = iniReader.ReadFloat("MISC", "LeftStickDeadzone", 10.0f);
@@ -177,10 +177,13 @@ void Init()
 
     if (bSkipIntro)
     {
-        auto pattern = hook::pattern("A3 ? ? ? ? A1 ? ? ? ? 6A 20 50"); //0xA9E6D8
-        injector::WriteMemory(*pattern.count(3).get(2).get<uint32_t*>(1), 1, true);
-        pattern = hook::pattern("A1 ? ? ? ? 85 C0 74 ? 57 8B F8 E8"); //0xA97BC0
-        injector::WriteMemory(*pattern.count(1).get(0).get<uint32_t*>(1), 1, true);
+        // EA Bumper
+        uint32_t* dword_6FC24A = hook::pattern("68 ? ? ? ? 6A ? FF D2 D9 EE").count(1).get(0).get<uint32_t>(1);
+        injector::WriteMemory(dword_6FC24A, &"SkipThis", true);
+        
+        // Attract
+        uint32_t* dword_6FC264 = hook::pattern("68 ? ? ? ? 6A ? 8B CE FF D2").count(1).get(0).get<uint32_t>(1);
+        injector::WriteMemory(dword_6FC264, &"SkipThis", true);
     }
 
     if (nWindowedMode)


### PR DESCRIPTION
# NFSMW 

- Added shadow bias code to ShadowsRes. Solves an issue that caused [shadow acne](https://digitalrune.github.io/DigitalRune-Documentation/html/3f4d959e-9c98-4a97-8d85-7a73c26145d7.htm) to appear for resolutions greater than 4096.
- Added ImproveShadowLOD feature. Restores missing shadows details and improves their quality. Disabled by default for performance reasons. [Video Demonstration](https://www.youtube.com/watch?v=ILb1-zcFUOU)

# NFSPS

- Replaced old SkipIntro code with new code. Fixed a bug that prevented the start menu video from playing.
- Disabled SkipIntro by default.

# SH3

- Added second mode to FramerateFluctuationFix. (1 = 60 FPS | 2 = 30 FPS).
- Enabled FramerateFluctuationFix by default.
