### PR TITLE
[NFS] [SH3] More features and bug fixes

### DIFF
--- a/data/NFSCarbon.WidescreenFix/scripts/NFSCarbon.WidescreenFix.ini
+++ b/data/NFSCarbon.WidescreenFix/scripts/NFSCarbon.WidescreenFix.ini
@@ -4,7 +4,7 @@ ResY = 0 // Controls vertical resolution.
 FixHUD = 1 // Corrects HUD aspect ratio.
 FixFOV = 1 // Corrects FOV aspect ratio.
 Scaling = 1 // Adjusts FOV scaling to match the console version. Requires FixFOV to be enabled. (1 = Xbox 360 | 2 = PS2)
-HudWidescreenMode = 1 // Moves HUD to the edge of the screen for 16:9. Install NFSC HUD Adapter for other aspect ratios.
+HUDWidescreenMode = 1 // Moves HUD to the edge of the screen for 16:9. Install NFSC HUD Adapter for other aspect ratios.
 FMVWidescreenMode = 1 // FMVs will appear in fullscreen.
 
 [MISC]

--- a/data/NFSMostWanted.WidescreenFix/scripts/NFSMostWanted.WidescreenFix.ini
+++ b/data/NFSMostWanted.WidescreenFix/scripts/NFSMostWanted.WidescreenFix.ini
@@ -10,6 +10,7 @@ FMVWidescreenMode = 1 // FMVs will appear in fullscreen.
 [MISC]
 ShadowsRes = 1024 // Controls the resolution of dynamic shadows and enables them for Intel GPUs.
 ShadowsFix = 1 // Dynamic shadows will no longer disappear when going into tunnels, under bridges, etc.
+ImproveShadowLOD = 0 // Increases the level of detail of dynamic shadows.
 RearviewMirrorFix = 1 // Enables rearview mirror for all camera views.
 CustomUserFilesDirectoryInGameDir = 0 // User files will be stored in a specified directory (for example: "save"). Use 0 to disable.
 WriteSettingsToFile = 0 // All registry settings will be saved to "settings.ini" in your profile folder. You must input your CD key and langauge in "settings.ini" when this option is enabled.

--- a/data/NFSMostWanted.WidescreenFix/scripts/NFSMostWanted.WidescreenFix.ini
+++ b/data/NFSMostWanted.WidescreenFix/scripts/NFSMostWanted.WidescreenFix.ini
@@ -4,7 +4,7 @@ ResY = 0 // Controls vertical resolution.
 FixHUD = 1 // Corrects HUD aspect ratio.
 FixFOV = 1 // Corrects FOV aspect ratio.
 Scaling = 1 // Adjusts FOV scaling to match the console version. Requires FixFOV to be enabled. (1 = Xbox 360 | 2 = PS2)
-HudWidescreenMode = 1 // Moves HUD to the edge of the screen for 16:9. Install NFSMW HUD Adapter for other aspect ratios.
+HUDWidescreenMode = 1 // Moves HUD to the edge of the screen for 16:9. Install NFSMW HUD Adapter for other aspect ratios.
 FMVWidescreenMode = 1 // FMVs will appear in fullscreen.
 
 [MISC]
@@ -15,4 +15,5 @@ RearviewMirrorFix = 1 // Enables rearview mirror for all camera views.
 CustomUserFilesDirectoryInGameDir = 0 // User files will be stored in a specified directory (for example: "save"). Use 0 to disable.
 WriteSettingsToFile = 0 // All registry settings will be saved to "settings.ini" in your profile folder. You must input your CD key and langauge in "settings.ini" when this option is enabled.
 ImproveGamepadSupport = 0 // Replaces keyboard icons with gamepad icons and assigns front-end actions. Requires an XInput gamepad. (1 = Xbox Icons | 2 = PlayStation Icons)
+DisableMotionBlur = 0 // Allows users to disable motion blur without changing registry settings.
 LeftStickDeadzone = 10.0 // Controls the deadzone of the left analog stick.

--- a/data/NFSProStreet.GenericFix/scripts/NFSProStreet.GenericFix.ini
+++ b/data/NFSProStreet.GenericFix/scripts/NFSProStreet.GenericFix.ini
@@ -14,4 +14,5 @@ WriteSettingsToFile = 0 // All registry settings will be saved to "settings.ini"
 ImproveGamepadSupport = 0 // Replaces keyboard icons with gamepad icons and assigns front-end actions. Requires an XInput gamepad. (1 = Xbox Icons | 2 = PlayStation Icons)
 LeftStickDeadzone = 10.0 // Controls the deadzone of the left analog stick.
 DisableMotionBlur = 0 // Disables motion blur without affecting the World FX setting.
+BrakeLightFix = 1 // Solves an issue that caused brake lights to only work when ABS was active.
 ShadowRes = 0 // Controls the resolution of dynamic shadows.

--- a/data/NFSUnderground.WidescreenFix/scripts/NFSUnderground.WidescreenFix.ini
+++ b/data/NFSUnderground.WidescreenFix/scripts/NFSUnderground.WidescreenFix.ini
@@ -4,7 +4,7 @@ ResY = 0 // Controls vertical resolution.
 FixHUD = 1 // Corrects HUD aspect ratio.
 FixFOV = 1 // Corrects FOV aspect ratio.
 Xbox360Scaling = 1 // Adjusts FOV scaling to match the Xbox 360 version of NFSMW. Requires FixFOV to be enabled.
-HudWidescreenMode = 1 // Moves HUD to the edge of the screen. Change offset in "NFSUnderground.WidescreenFix.dat" file.
+HUDWidescreenMode = 1 // Moves HUD to the edge of the screen. Change offset in "NFSUnderground.WidescreenFix.dat" file.
 FMVWidescreenMode = 1 // FMVs will appear in fullscreen.
 
 [MISC]

--- a/data/NFSUnderground2.WidescreenFix/scripts/NFSUnderground2.WidescreenFix.ini
+++ b/data/NFSUnderground2.WidescreenFix/scripts/NFSUnderground2.WidescreenFix.ini
@@ -4,7 +4,7 @@ ResY = 0 // Controls vertical resolution.
 FixHUD = 1 // Corrects HUD aspect ratio.
 FixFOV = 1 // Corrects FOV aspect ratio.
 Xbox360Scaling = 1 // Adjusts FOV scaling to match the Xbox 360 version of NFSMW. Requires FixFOV to be enabled.
-HudWidescreenMode = 1 // Moves HUD to the edge of the screen. Change offset in "NFSUnderground2.WidescreenFix.dat" file.
+HUDWidescreenMode = 1 // Moves HUD to the edge of the screen. Change offset in "NFSUnderground2.WidescreenFix.dat" file.
 FMVWidescreenMode = 1 // FMVs will appear in fullscreen.
 
 [MISC]
@@ -12,4 +12,6 @@ DisableCutsceneBorders = 1 // Removes letterboxing that appears during cutscenes
 CustomUserFilesDirectoryInGameDir = 0 // User files will be stored in a specified directory (for example: "save"). Use 0 to disable.
 WriteSettingsToFile = 0 // All registry settings will be saved to "settings.ini" in your profile folder. You must input your CD key and langauge in "settings.ini" when this option is enabled.
 ImproveGamepadSupport = 0 // Adds text to buttons and assigns front-end actions. Requires an XInput gamepad. (1 = Xbox Text | 2 = PlayStation Text | 3 = PC Text)
+60FPSCutscenes = 1 // Increases the framerate limit for cutscenes to 60 FPS.
+SingleCoreAffinity = 0 // Limits game to one CPU core to prevent crashing.
 LeftStickDeadzone = 10.0 // Controls the deadzone of the left analog stick.

--- a/data/SilentHill3.WidescreenFix/scripts/SilentHill3.WidescreenFix.ini
+++ b/data/SilentHill3.WidescreenFix/scripts/SilentHill3.WidescreenFix.ini
@@ -14,7 +14,7 @@ PixelationFix = 1 // Subtracts 0.5 from render resolution to fix transition bug.
 StatusScreenRes = 512 // Controls resolution of status screen image.
 ShadowsRes = 1024 // Controls resolution of dynamic shadows.
 DOFRes = 1024 // Controls resolution of depth of field and other blur effects.
-FrameRateFluctuationFix = 0 // Framerate won't drop to 30fps, but user must be capable of maintaining 60fps.
+FrameRateFluctuationFix = 1 // Prevents the framerate from jumping between 60 FPS and 30 FPS. (1 = 60 FPS | 2 = 30 FPS)
 ReduceCutsceneFOV = 0 // Cutscenes will use vert- scaling to hide off-screen characters.
 SH2Reference = 1 // Enables several SH2 references for new saves. A feature from sh3proxy.
 FogComplexity = 75 // The higher the value, the more detailed the fog appears. 25 = original value.

--- a/source/NFSCarbon.WidescreenFix/dllmain.cpp
+++ b/source/NFSCarbon.WidescreenFix/dllmain.cpp
@@ -20,7 +20,7 @@ void Init()
     bool bFixHUD = iniReader.ReadInteger("MAIN", "FixHUD", 1) != 0;
     bool bFixFOV = iniReader.ReadInteger("MAIN", "FixFOV", 1) != 0;
     int32_t nScaling = iniReader.ReadInteger("MAIN", "Scaling", 2);
-    bool bHudWidescreenMode = iniReader.ReadInteger("MAIN", "HudWidescreenMode", 1) != 0;
+    bool bHUDWidescreenMode = iniReader.ReadInteger("MAIN", "HUDWidescreenMode", 1) != 0;
     int32_t nFMVWidescreenMode = iniReader.ReadInteger("MAIN", "FMVWidescreenMode", 1);
     int32_t nWindowedMode = iniReader.ReadInteger("MISC", "WindowedMode", 0);
     bool bSkipIntro = iniReader.ReadInteger("MISC", "SkipIntro", 1) != 0;
@@ -277,7 +277,7 @@ void Init()
         }
     }
 
-    if (bHudWidescreenMode)
+    if (bHUDWidescreenMode)
     {
         uint32_t* dword_5DC508 = hook::pattern("0F 95 C1 3A C1 75 2B 8B 0D ? ? ? ? 3B CE").count(1).get(0).get<uint32_t>(1);
         injector::WriteMemory<uint8_t>(dword_5DC508, 0x94, true);
@@ -588,6 +588,13 @@ void Init()
                 *(uint32_t*)(*(uint32_t*)dword_A98874 + 0x20) = 3; // "1"; changed A to Y
             }
         }; injector::MakeInline<MenuRemap>(pattern.get_first(0), pattern.get_first(6));
+
+        // Start menu text
+        uint32_t* dword_8577AC = hook::pattern("68 ? ? ? ? 68 ? ? ? ? 51 E8 ? ? ? ? 83 C4 14 E8").count(1).get(0).get<uint32_t>(1);
+        if (nImproveGamepadSupport == 1)
+            injector::WriteMemory(dword_8577AC, 0x186AAECC, true); //"Press START to begin" (Xbox)
+        else
+            injector::WriteMemory(dword_8577AC, 0x703A92CC, true); //"Press START button" (PlayStation)
     }
 
     if (bExpandControllerOptions)

--- a/source/NFSMostWanted.WidescreenFix/dllmain.cpp
+++ b/source/NFSMostWanted.WidescreenFix/dllmain.cpp
@@ -21,9 +21,10 @@ void Init()
     bool bFixFOV = iniReader.ReadInteger("MAIN", "FixFOV", 1) != 0;
     bool bHudWidescreenMode = iniReader.ReadInteger("MAIN", "HudWidescreenMode", 1) == 1;
     bool bFMVWidescreenMode = iniReader.ReadInteger("MAIN", "FMVWidescreenMode", 1) == 1;
-    int nScaling = iniReader.ReadInteger("MAIN", "Scaling", 2);
+    int nScaling = iniReader.ReadInteger("MAIN", "Scaling", 1);
     int ShadowsRes = iniReader.ReadInteger("MISC", "ShadowsRes", 1024);
-    bool bShadowsFix = iniReader.ReadInteger("MISC", "ShadowsFix", 1) == 1;
+    bool bShadowsFix = iniReader.ReadInteger("MISC", "ShadowsFix", 1) != 0;
+    bool bImproveShadowLOD = iniReader.ReadInteger("MISC", "ImproveShadowLOD", 0) != 0;
     bool bRearviewMirrorFix = iniReader.ReadInteger("MISC", "RearviewMirrorFix", 1) == 1;
     static auto szCustomUserFilesDirectoryInGameDir = iniReader.ReadString("MISC", "CustomUserFilesDirectoryInGameDir", "");
     bool bWriteSettingsToFile = iniReader.ReadInteger("MISC", "WriteSettingsToFile", 1) != 0;
@@ -135,6 +136,22 @@ void Init()
             uint32_t* dword__93D898 = hook::pattern(pattern_str(to_bytes(dword_93D898))).count(1).get(0).get<uint32_t>(0);
             injector::WriteMemory(dword__93D898, dword_8F1CA0, true);
         }
+
+        // solves shadow acne problem for resolutions greater than 4096
+        if (ShadowsRes > 4096)
+        {
+            static float ShadowBias = (ShadowsRes / 4096.0f) * 4.0f;
+            uint32_t* dword_6E5509 = hook::pattern("8B 15 ? ? ? ? A1 ? ? ? ? 8B 08 52 68").count(1).get(0).get<uint32_t>(2);
+            injector::WriteMemory(dword_6E5509, &ShadowBias, true);
+        }
+    }
+
+    if (bImproveShadowLOD)
+    {
+        uint32_t* dword_6E5174 = hook::pattern("68 ? ? ? ? EB ? A1 ? ? ? ? 0D").count(1).get(0).get<uint32_t>(1);
+        injector::WriteMemory(dword_6E5174, 0x00000000, true);
+        uint32_t* dword_6BFFA2 = hook::pattern("68 ? ? ? ? 50 41 68").count(2).get(1).get<uint32_t>(1);
+        injector::WriteMemory(dword_6BFFA2, 0x00006102, true);
     }
 
     //HUD

--- a/source/NFSProStreet.GenericFix/dllmain.cpp
+++ b/source/NFSProStreet.GenericFix/dllmain.cpp
@@ -157,7 +157,7 @@ void Init()
 
 
     bool bFixHUD = iniReader.ReadInteger("MISC", "FixHUD", 1) != 0;
-    bool bSkipIntro = iniReader.ReadInteger("MISC", "SkipIntro", 1) != 0;
+    bool bSkipIntro = iniReader.ReadInteger("MISC", "SkipIntro", 0) != 0;
     static int32_t nWindowedMode = iniReader.ReadInteger("MISC", "WindowedMode", 0);
     static int32_t nImproveGamepadSupport = iniReader.ReadInteger("MISC", "ImproveGamepadSupport", 0);
     static float fLeftStickDeadzone = iniReader.ReadFloat("MISC", "LeftStickDeadzone", 10.0f);
@@ -177,10 +177,13 @@ void Init()
 
     if (bSkipIntro)
     {
-        auto pattern = hook::pattern("A3 ? ? ? ? A1 ? ? ? ? 6A 20 50"); //0xA9E6D8
-        injector::WriteMemory(*pattern.count(3).get(2).get<uint32_t*>(1), 1, true);
-        pattern = hook::pattern("A1 ? ? ? ? 85 C0 74 ? 57 8B F8 E8"); //0xA97BC0
-        injector::WriteMemory(*pattern.count(1).get(0).get<uint32_t*>(1), 1, true);
+        // EA Bumper
+        uint32_t* dword_6FC24A = hook::pattern("68 ? ? ? ? 6A ? FF D2 D9 EE").count(1).get(0).get<uint32_t>(1);
+        injector::WriteMemory(dword_6FC24A, &"SkipThis", true);
+        
+        // Attract
+        uint32_t* dword_6FC264 = hook::pattern("68 ? ? ? ? 6A ? 8B CE FF D2").count(1).get(0).get<uint32_t>(1);
+        injector::WriteMemory(dword_6FC264, &"SkipThis", true);
     }
 
     if (nWindowedMode)

--- a/source/SilentHill3.WidescreenFix/dllmain.cpp
+++ b/source/SilentHill3.WidescreenFix/dllmain.cpp
@@ -290,21 +290,22 @@ void Init()
         injector::MakeCALL(pattern.get_first(0), static_cast<float(*)()>(ret_088), true);
 
         //Splash
-        static float fHudOffsetReal = (Screen.fWidth - Screen.fHeight * (4.0f / 3.0f)) / 2.0f;
-        static float w2 = Screen.fWidth - fHudOffsetReal;
+        static float fTextureOffset1 = (Screen.fWidth - Screen.fHeight * (4.0f / 3.0f)) / 2.0f;
+        static float fTextureOffset2 = (fTextureOffset1 / (Screen.fWidth / RenderResX));
+        static float w2 = RenderResX - fTextureOffset2;
         pattern = hook::pattern("A1 ? ? ? ? 6A 05 C7 44 24 18"); //005D744A
-        injector::WriteMemory<float>(pattern.get_first(11), fHudOffsetReal, true);
+        injector::WriteMemory<float>(pattern.get_first(11), fTextureOffset2, true);
         pattern = hook::pattern("C7 44 24 50 ? ? ? ? C7 44 24 58 ? ? ? ? C7 44 24 5C ? ? ? ? C7 44 24 64"); //005D74B0 
-        injector::WriteMemory<float>(pattern.get_first(4), fHudOffsetReal, true);
+        injector::WriteMemory<float>(pattern.get_first(4), fTextureOffset2, true);
         pattern = hook::pattern("D8 25 ? ? ? ? 8D 54 24 0C 52 6A 02"); //005D7414 
         injector::WriteMemory<uint16_t>(pattern.get_first(0), 0x05D9i16, true); //fsub -> fld
         injector::WriteMemory(pattern.get_first(2), &w2, true);
 
         //Credits
         pattern = hook::pattern("6A 05 C7 44 24 1C"); //0059BE49 
-        injector::WriteMemory<float>(pattern.get_first(6), fHudOffsetReal, true);
+        injector::WriteMemory<float>(pattern.get_first(6), fTextureOffset2, true);
         pattern = hook::pattern("C7 44 24 54 ? ? ? ? C7 44 24 5C ? ? ? ? C7 44 24 60 ? ? ? ? C7 44 24 68"); //0059BEAF 
-        injector::WriteMemory<float>(pattern.get_first(4), fHudOffsetReal, true);
+        injector::WriteMemory<float>(pattern.get_first(4), fTextureOffset2, true);
         pattern = hook::pattern("D8 25 ? ? ? ? 8D 4C 24 10 51 6A 02 D9 54 24 34 "); //0059BE13 
         injector::WriteMemory<uint16_t>(pattern.get_first(0), 0x05D9i16, true); //fsub -> fld
         injector::WriteMemory(pattern.get_first(2), &w2, true);


### PR DESCRIPTION
# NFSPS

- Added code to enable HD_GROUP texture on start screen.
- Added code to change start screen text for ImproveGamepadSupport.
- Added option for BrakeLightFix.

# NFSC

- Added code to change start screen text for ImproveGamepadSupport.
- Renamed HudWidescreenMode to HUDWidescreenMode.

# NFSMW

- Added code to change start screen text for ImproveGamepadSupport.
- Added DisableMotionBlur. This was added so people wouldn't need to modify their registry.
- Renamed HudWidescreenMode to HUDWidescreenMode.

# NFSU2

- Added code to change start screen text for ImproveGamepadSupport.
- Added code for front-end gamepad actions that were either unused or not assigned correctly.
- Restored LB/RB (L1/R1) front-end functionality.
- Replaced "P" key emulation with new remapping code. _Note: old code has been commented, not deleted._
- Added SingleCoreAffinity. It apparently [prevents random crashing](https://www.pcgamingwiki.com/wiki/Need_for_Speed:_Underground_2#Random_crashing_on_entering.2Fexiting_shops) when exiting shops.
- Added 60FPSCutscenes. They were hardcoded to run at 30 FPS.
- Renamed HudWidescreenMode to HUDWidescreenMode.

# NFSU

- Added code for front-end gamepad actions that were either unused or not assigned correctly.
- Restored LB/RB (L1/R1) front-end functionality.
- Renamed HudWidescreenMode to HUDWidescreenMode.

# SH3

- Fixed splash screen aspect ratio bug.
