### PR TITLE
[NFSU] Black Magazine Cover Fix

### DIFF
--- a/data/NFSUnderground.WidescreenFix/scripts/NFSUnderground.WidescreenFix.ini
+++ b/data/NFSUnderground.WidescreenFix/scripts/NFSUnderground.WidescreenFix.ini
@@ -12,3 +12,4 @@ CustomUserFilesDirectoryInGameDir = 0 // User files will be stored in a specifie
 ImproveGamepadSupport = 0 // Replaces keyboard icons with gamepad icons and assigns front-end actions. Requires an XInput gamepad. (1 = Xbox Icons | 2 = PlayStation Icons)
 LeftStickDeadzone = 10.0 // Controls the deadzone of the left analog stick.
 D3DHookBorders = 1 // Adds borders to the front-end to hide debug objects.
+BlackMagazineFix = 1 // Fixes black background in magazine covers

--- a/readme.md
+++ b/readme.md
@@ -590,6 +590,8 @@ The usage is as simple as inserting the files into game's root directory. Uninst
 
 ![](https://habrastorage.org/webt/ow/yy/mg/owyymgpibfqzfbwyf_iqoiqrede.png) Fixed FMVs
 
+![](https://habrastorage.org/webt/ow/yy/mg/owyymgpibfqzfbwyf_iqoiqrede.png) Fixed black magazine covers
+
 ![](https://habrastorage.org/webt/d_/eg/ym/d_egymd6w_tem2erocab-e9ikna.png) Added an option to switch between different 3D scaling
 
 ![](https://habrastorage.org/webt/d_/eg/ym/d_egymd6w_tem2erocab-e9ikna.png) Added an option to make FMVs fullscreen


### PR DESCRIPTION
This is a fix for a bug in the original game code, not a problem with WidescreenFix, but as explained in #862, this seems like a good place to include it.

When motion blur or light trails are turned on, the background of magazine covers are black.

[Example with Light Trails disabled](https://i.imgur.com/oILt4B9.png)
[Example with Light Trails enabled](https://i.imgur.com/miSF6Sf.png)

Let me know if you think the patch is too big for the project to take it.
Closes #862.

## Cause

**TLDR** rendering surface on which background was drawn is cleared during the render of the car.

The rendering of the screen is divided in three steps:

 1. 2D Background Renderer. Seems to be used only to render the background of magazine covers.
 2. 3D Scene Renderer. Used to render everything that is 3D.
 3. 2D Foreground Renderer. Used to draw HUDs, menus, magazine foregrounds, etc.

When motion blur and/or light trails are disabled, the result of the first two steps are put directly in the back buffer. On the other hand, when those effects are enabled, they are rendered into a texture surface in such a way that it can be manipulated to produce the special effects, after which it is finally drawn in the back buffer.

When a texture surface is used as the target for the 3D Scene, it is filled with black beforehand. This is desirable, as in normal circumstances it contains the result of the previous frame. However, when a magazine is being rendered, it also contains the result of the first rendering step, the background of the magazine, which ends up discarded.

To better visualize the issue, check the following render snapshots:

[Render Snapshot with FX disabled](https://imgur.com/a/oUzbxWL)
[Render Snapshot with FX enabled](https://imgur.com/a/L00iUBN)

(Do note that the back buffer isn't cleared in the first step, but before it, right at the beginning of the frame)

## Solution

Two pieces of code need to be patched in order to fix this. First, the second step shouldn't clear the rendering surface when a magazine is being displayed. Secondly, since the surface isn't being cleared anymore (and may contain artifacts), we have to clear it during the first step.

To keep the changes safe from additional side-effects, we keep the rendering as is, and change it only if the magazine screen is open. I have traced a boolean (`byte_735768`) that can be used for this check.

The first patch is applied at the following piece of code in the `sub_409580` (I call it `??Render3DScene`):

```asm
.text:004098A2                 cmp     dword_73645C, 1  ; <== PATCH APPLIED HERE
.text:004098A9                 mov     esi, [edi+58h]
.text:004098AC                 jnz     short loc_4098B2
.text:004098AE                 push    1
.text:004098B0                 jmp     short loc_4098B4
.text:004098B2 ; ---------------------------------------------------------------------------
.text:004098B2
.text:004098B2 loc_4098B2:
.text:004098B2                 push    0
.text:004098B4
.text:004098B4 loc_4098B4:
.text:004098B4                 call    ??SetRenderTarget
```

This `dword_73645C` specifies whether any effect is enabled, and in this context is used to either push `0` or `1` as the parameter of the function used to setup a render target. This parameter specifies whether or not to clear the surface.

Do note the patch cannot be applied without inline assembly, by modifying the function pointer in `call ??SetRenderTarget`, because it uses a non-standard calling convention (`esi` is the first parameter).

The second patch is applied at the following piece of `sub_409CD0` (I call it `??Render2DStuff`):

```asm
.text:00409CE7                 test    ebx, ebx
.text:00409CE9                 push    0
.text:00409CEB                 mov     esi, offset unk_71AA30
.text:00409CF0                 jz      short loc_409CF7
.text:00409CF2                 mov     esi, offset unk_71AA4C  ; <== PATCH APPLIED HERE
.text:00409CF7
.text:00409CF7 loc_409CF7:
.text:00409CF7                 call    ??SetRenderTarget
```

The piece of code we patch is only executed if this is the first render step (i.e. not the third one). In this case, we set the clear render target parameter to `1` if we aren't going to clear it in the second render step.