### PR TITLE
[NFSUC][NFSPS] aspect ratio bug fix, additional scaling options

### DIFF
--- a/data/NFSProStreet.GenericFix/scripts/NFSProStreet.GenericFix.ini
+++ b/data/NFSProStreet.GenericFix/scripts/NFSProStreet.GenericFix.ini
@@ -7,7 +7,7 @@ AntiDamageModelCrash = 1
 
 [MAIN]
 FixAspectRatio = 1 // Corrects the width of the HUD, FOV, and FMVs.
-Scaling = 1 // Adjusts FOV scaling to match the Xbox 360 version. Requires FixAspectRatio to be enabled.
+Scaling = 1 // Adjusts FOV scaling. Requires FixAspectRatio to be enabled. (1 = Xbox 360 | 2 = Proportionally Correct)
 HUDWidescreenMode = 1 // Moves HUD to the edge of the screen for 16:9. Disable this feature if you're using an aspect ratio less than 16:9.
 FMVWidescreenMode = 1 // FMVs will appear in fullscreen. Requires FixAspectRatio to be enabled.
 ConsoleHUDSize = 1 // Makes the HUD smaller, as the developers intended.

--- a/data/NFSUndercover.GenericFix/scripts/NFSUndercover.GenericFix.ini
+++ b/data/NFSUndercover.GenericFix/scripts/NFSUndercover.GenericFix.ini
@@ -2,7 +2,7 @@
 ResDetect = 1
 
 [MAIN]
-HUDWidescreenMode = 1 // Moves HUD to the edge of the screen for 16:9. Disable this feature if you're using an aspect ratio less than 16:9.
+Scaling = 0 // // Adjusts FOV scaling to be more proportionally correct than the original scaling.
 
 [MISC]
 SkipIntro = 0 // Skips FMVs that play when you launch the game.


### PR DESCRIPTION
Based on issue https://github.com/ThirteenAG/WidescreenFixesPack/issues/877#
This is an important bug fix, as the current releases don't work correctly for any aspect ratio other than 16:9.

[NFSUC]
- Fixed critical aspect ratio bug
- Added Scaling = 1 for proportionally correct image
- Removed HUDWidescreenMode and automated the code based on aspect ratio

[NFSPS]
- Fixed critical aspect ratio bug
- Added Scaling = 2 for proportionally correct image