### PR TITLE
[NFSU2] Performance improvement

### DIFF
--- a/data/NFSUnderground2.WidescreenFix/scripts/NFSUnderground2.WidescreenFix.ini
+++ b/data/NFSUnderground2.WidescreenFix/scripts/NFSUnderground2.WidescreenFix.ini
@@ -15,5 +15,5 @@ WriteSettingsToFile = 0                  // All registry settings will be saved 
 ImproveGamepadSupport = 0                // Adds text to buttons and assigns front-end actions. Requires an XInput gamepad. (1 = Xbox Text | 2 = PlayStation Text | 3 = PC Text | 4 = None)
 FPSLimit = 120                           // Allows users to control the framerate limit.
 60FPSCutscenes = 1                       // Increases the framerate limit for cutscenes to 60.
-SingleCoreAffinity = 0                   // Limits game to one CPU core to prevent crashing, but may negatively affect framerate.
+SingleCoreAffinity = 1                   // Limits game to one CPU core to prevent crashing.
 LeftStickDeadzone = 10.0                 // Controls the deadzone of the left analog stick.

--- a/source/NFSUnderground2.WidescreenFix/dllmain.cpp
+++ b/source/NFSUnderground2.WidescreenFix/dllmain.cpp
@@ -694,12 +694,13 @@ void Init()
 
     if (bSingleCoreAffinity)
     {
-        IMAGE_DOS_HEADER* Imagebase = (IMAGE_DOS_HEADER*)GetModuleHandle(NULL);
-	    IMAGE_NT_HEADERS* ntHeader = (IMAGE_NT_HEADERS*)((uintptr_t)Imagebase + Imagebase->e_lfanew);
-	    IMAGE_SECTION_HEADER* rdataHeader = ((IMAGE_SECTION_HEADER*)(ntHeader+1)) + 1;
-	    uintptr_t rdata = (uintptr_t)Imagebase + rdataHeader->VirtualAddress;
-        uintptr_t* imp_CreateThread = std::find((uintptr_t*)rdata, (uintptr_t*)((BYTE*)rdata + rdataHeader->SizeOfRawData), (uintptr_t)CreateThread);
-		if (imp_CreateThread != NULL) {
+		IMAGE_DOS_HEADER* Imagebase = (IMAGE_DOS_HEADER*)GetModuleHandle(NULL);
+		IMAGE_NT_HEADERS* ntHeader = (IMAGE_NT_HEADERS*)((uintptr_t)Imagebase + Imagebase->e_lfanew);
+		IMAGE_SECTION_HEADER* rdataHeader = ((IMAGE_SECTION_HEADER*)(ntHeader + 1)) + 1;
+		uintptr_t rdata = (uintptr_t)Imagebase + rdataHeader->VirtualAddress;
+		uintptr_t* rdata_end = (uintptr_t*)(rdata + rdataHeader->SizeOfRawData);
+		uintptr_t* imp_CreateThread = std::find((uintptr_t*)rdata, rdata_end, (uintptr_t)CreateThread);
+		if (imp_CreateThread != rdata_end) {
 			SetThreadAffinityMask(GetCurrentThread(), AffinityMask);
 			injector::WriteMemory(imp_CreateThread, CreateThread_Hook, true);
 		}


### PR DESCRIPTION
Brief:
There's game crashes on multicores CPUs - reading 0xAAAAAAAA pointer, the only function that sets this value is MemoryPool::AllocateMemory and it is have mutex lock, may be problem is in bWareMalloc which is modifing MemoryPool without mutex lock, idk, this crashes happens so randomly so I can't test it.
The common fix is setting single core affinity on WHOLE process, which is causing performance issue: my 2.5 GHz Kaby Lake can't event provide 60 FPS. Is Kaby Lake weaker than Pentium 4? No, this is due to Nvidia drivers for Pascal.
![image](https://user-images.githubusercontent.com/59743349/149674669-32808b3c-5ee6-437b-b31b-69cd75cfeeea.png)

Current NFSU2 WSFix version is also setting single core affinity on whole process.
In this pull request, only threads that are created directly by the game gets single core affinity, which is completly solving both game crashes and performance issues.
This driver's threads also has too much priority, down-prioritize driver's threads or up-prioritize game threads is also improve performance but idk about anouther Nvidia and AMD drivers.
P.S. I almost made resolution settings works in the game menu by replacing only last avaible resolution option and its string (without HUD rescaling yet), but idk is it worth it.
![image](https://user-images.githubusercontent.com/59743349/149675369-004b1334-23aa-4614-9f70-fb23978855fb.png)

