### PR TITLE
SCCT: Fix other misaligned texts for italian ver

### DIFF
--- a/source/SplinterCellChaosTheory.WidescreenFix/dllmain.cpp
+++ b/source/SplinterCellChaosTheory.WidescreenFix/dllmain.cpp
@@ -416,7 +416,8 @@ void Init()
     switch (eGameLang) {
     case GameLang::Italian:
         sTextOffset.bottomCorner.v1v1 -= 7;
-        sTextOffset.topCorner.v2v2 += 1;
+        sTextOffset.objPopup.v2v2 += 5;
+        sTextOffset.topCorner.v2v2 += 3;
         break;
     case GameLang::Polish:
         sTextOffset.bottomCorner.v1v1 -= 10;


### PR DESCRIPTION
https://github.com/ThirteenAG/WidescreenFixesPack/issues/979
Fix other misaligned texts for italian version of the game. 