### PR TITLE
SCCT: Fix another misaligned text for italian ver

### DIFF
--- a/source/SplinterCellChaosTheory.WidescreenFix/dllmain.cpp
+++ b/source/SplinterCellChaosTheory.WidescreenFix/dllmain.cpp
@@ -417,7 +417,7 @@ void Init()
     case GameLang::Italian:
         sTextOffset.bottomCorner.v1v1 -= 7;
         sTextOffset.objPopup.v2v2 += 5;
-        sTextOffset.topCorner.v2v2 += 3;
+        sTextOffset.topCorner.v2v2 += 4;
         break;
     case GameLang::Polish:
         sTextOffset.bottomCorner.v1v1 -= 10;


### PR DESCRIPTION
Fixed another misaligned text in the last level for the Italian version of the game:
![scr1](https://user-images.githubusercontent.com/62349018/186478240-b5a8e32c-a525-4fba-9e9a-8cf5aa5055cb.png)

![scr2](https://user-images.githubusercontent.com/62349018/186478269-3f488cff-0887-45ed-901e-3e64dfd652e7.png)

