### PR TITLE
[NFSUC] implement scenery improvements

### DIFF
--- a/data/NFSUndercover.GenericFix/scripts/NFSUndercover.GenericFix.ini
+++ b/data/NFSUndercover.GenericFix/scripts/NFSUndercover.GenericFix.ini
@@ -19,3 +19,4 @@ CSMScale = 1.0                           // Overall scale of the cascade shadow 
 CSMScaleNear = 100.0                     // Nearest cascade (100.0 = Default | 5.0 = Game Default)
 CSMScaleMid = 175.0                      // Mid cascade (175.0 = Default | 30.0 = Game Default)
 CSMScaleFar = 300.0                      // Far cascade (300.0 = Default | 170.0 = Game Default)
+ImproveSceneryLOD = 1                    // Increases visible scenery on screen.


### PR DESCRIPTION
This will increase/restore the visible scenery on the screen, as well as reduce culling while going around.

This does NOT fix flickering scenery (in shadows/envmap/main view). That is caused by some other bug in the game.

Examples:

Before:
![image](https://user-images.githubusercontent.com/8014093/189497856-05cac42c-b1a1-474b-ade6-8b324f688c17.png)

After:
![image](https://user-images.githubusercontent.com/8014093/189497862-44e6cda2-6c91-4f10-9643-36a2775de265.png)
