### PR TITLE
[NFSU] implement FPS limit adjustments

### DIFF
--- a/data/NFSUnderground.WidescreenFix/scripts/NFSUnderground.WidescreenFix.ini
+++ b/data/NFSUnderground.WidescreenFix/scripts/NFSUnderground.WidescreenFix.ini
@@ -13,5 +13,6 @@ WindowedMode = 0                         // 1 activates borderless windowed mode
 HideDebugObjects = 1                     // Hides debug objects. (1 = Removed by code | 2 = Adds borders to the front-end)
 CustomUserFilesDirectoryInGameDir = 0    // User files will be stored in a specified directory (for example: "save"). Use '0' to disable.
 ImproveGamepadSupport = 0                // Replaces keyboard icons with gamepad icons and assigns front-end actions. Requires an XInput gamepad. (1 = Xbox Icons | 2 = PlayStation Icons | 3 = None)
+FPSLimit = 60                            // Allows users to control the framerate limit.
 BlackMagazineFix = 0                     // Fixes black background in magazine covers. May not be compatible with all versions of the game.
 LeftStickDeadzone = 10.0                 // Controls the deadzone of the left analog stick.

--- a/readme.md
+++ b/readme.md
@@ -734,6 +734,8 @@ The usage is as simple as inserting the files into game's root directory. Uninst
 
 ![](https://habrastorage.org/webt/d_/eg/ym/d_egymd6w_tem2erocab-e9ikna.png) Added an option to improve gamepad support (gamepad icons, fixed bindings etc)
 
+![](https://habrastorage.org/webt/d_/eg/ym/d_egymd6w_tem2erocab-e9ikna.png) Added an option to change fps limit
+
 ![](https://habrastorage.org/webt/d_/eg/ym/d_egymd6w_tem2erocab-e9ikna.png) Added an option to increase deadzone for left stick
 
 [Download](http://thirteenag.github.io/wfp#nfsu)

--- a/source/NFSUnderground.WidescreenFix/dllmain.cpp
+++ b/source/NFSUnderground.WidescreenFix/dllmain.cpp
@@ -1032,6 +1032,9 @@ void Init()
         if (FrameSeconds < 60.0)
             FrameSeconds = 60.0;
         injector::WriteMemory(dword_6CC8B0, FrameSeconds, true);
+        // another frametime -- seems to affect some gameplay elements...
+        uint32_t* dword_6B5C08 = *hook::pattern("DF E0 F6 C4 41 7A ? 8A 44 24 12 D9 05 ? ? ? ?").count(1).get(0).get<uint32_t*>(13);
+        injector::WriteMemory(dword_6B5C08, FrameTime, true);
     }
 
     // windowed mode

--- a/source/NFSUnderground.WidescreenFix/dllmain.cpp
+++ b/source/NFSUnderground.WidescreenFix/dllmain.cpp
@@ -1026,6 +1026,12 @@ void Init()
         // a function in eDisplayFrame (particle effects?) frametime
         uint32_t* dword_40A744 = hook::pattern("68 89 88 88 3C").count(1).get(0).get<uint32_t>(1);
         injector::WriteMemory(dword_40A744, FrameTime, true);
+        // something related to framerate and/or seconds. This value has to be an integer multiple of 60, otherwise the game can freeze. This affects some gameplay features such as NOS and menus.
+        uint32_t* dword_6CC8B0 = *hook::pattern("83 E1 01 0B F9 D9 44 24 28 D8 1D ? ? ? ?").count(1).get(0).get<uint32_t*>(11);
+        static float FrameSeconds = nFPSLimit - (nFPSLimit % 60);
+        if (FrameSeconds < 60.0)
+            FrameSeconds = 60.0;
+        injector::WriteMemory(dword_6CC8B0, FrameSeconds, true);
     }
 
     // windowed mode

--- a/source/NFSUnderground.WidescreenFix/dllmain.cpp
+++ b/source/NFSUnderground.WidescreenFix/dllmain.cpp
@@ -354,6 +354,7 @@ void Init()
     static auto szCustomUserFilesDirectoryInGameDir = iniReader.ReadString("MISC", "CustomUserFilesDirectoryInGameDir", "0");
     static int nImproveGamepadSupport = iniReader.ReadInteger("MISC", "ImproveGamepadSupport", 0);
     static float fLeftStickDeadzone = iniReader.ReadFloat("MISC", "LeftStickDeadzone", 10.0f);
+    static int nFPSLimit = iniReader.ReadInteger("MISC", "FPSLimit", 120);
     int nHideDebugObjects = iniReader.ReadInteger("MISC", "HideDebugObjects", 0);
     bool bBlackMagazineFix = iniReader.ReadInteger("MISC", "BlackMagazineFix", 0) != 0;
     if (szCustomUserFilesDirectoryInGameDir.empty() || szCustomUserFilesDirectoryInGameDir == "0")
@@ -1009,6 +1010,24 @@ void Init()
     {
         injector::MakeCALL(pattern.get_first(0), strlen, true);
     }
+
+    if (nFPSLimit)
+    {
+        // the game limits FPS 2x over the frametime (or just reports it that way to D3D) -- this is the real game framerate here!
+        static float FrameTime = 1.0f / nFPSLimit;
+        // Video mode frametime
+        uint32_t* dword_6CC7B0 = *hook::pattern("83 EC 10 A1 ? ? ? ? 89 44 24 04").count(1).get(0).get<uint32_t*>(31);
+        injector::WriteMemory(dword_6CC7B0, FrameTime, true);
+        // RealTimestep frametime
+        uint32_t* dword_6F0890 = *hook::pattern("99 D9 05 ? ? ? ? B9 64 00 00 00").count(1).get(0).get<uint32_t*>(3);
+        injector::WriteMemory(dword_6F0890, FrameTime, true);
+        uint32_t* dword_6CCDEC = *hook::pattern("99 D9 05 ? ? ? ? B9 64 00 00 00").count(1).get(0).get<uint32_t*>(63);
+        injector::WriteMemory(dword_6CCDEC, FrameTime * 2.0f, true);
+        // a function in eDisplayFrame (particle effects?) frametime
+        uint32_t* dword_40A744 = hook::pattern("68 89 88 88 3C").count(1).get(0).get<uint32_t>(1);
+        injector::WriteMemory(dword_40A744, FrameTime, true);
+    }
+
     // windowed mode
     if (nWindowedMode)
     {


### PR DESCRIPTION
This implements the same FPS limiter adjusters from Underground 2 to Underground.

The only difference is that the game either renders or reports the framerate at 2x the amount, but internally it's running at half rate.

This can be proven by playing around with the debug camera - if it goes over 99FPS, you can't turn over 180 degrees.

(I'm still testing this, I might add one more thing. races seem to end quicker than expected)