### PR TITLE
[NFSU] framelimit bugfix

### DIFF
--- a/source/NFSUnderground.WidescreenFix/dllmain.cpp
+++ b/source/NFSUnderground.WidescreenFix/dllmain.cpp
@@ -1028,7 +1028,15 @@ void Init()
         injector::WriteMemory(dword_40A744, FrameTime, true);
         // something related to framerate and/or seconds. This value has to be an integer multiple of 60, otherwise the game can freeze. This affects some gameplay features such as NOS and menus.
         uint32_t* dword_6CC8B0 = *hook::pattern("83 E1 01 0B F9 D9 44 24 28 D8 1D ? ? ? ?").count(1).get(0).get<uint32_t*>(11);
-        static float FrameSeconds = nFPSLimit - (nFPSLimit % 60);
+        static float FrameSeconds = nFPSLimit;
+
+        if (nFPSLimit % 60)
+            FrameSeconds = nFPSLimit - (nFPSLimit % 60);
+
+        // needed to avoid crashes, anything above 120 seems to be problematic at the moment...
+        if (FrameSeconds > 120.0f)
+            FrameSeconds = 120.0f;
+
         if (FrameSeconds < 60.0)
             FrameSeconds = 60.0;
         injector::WriteMemory(dword_6CC8B0, FrameSeconds, true);


### PR DESCRIPTION
To avoid possible crashes and hangs with high FPS limits, the FrameSeconds var needed to be limited to max 120. Game doesn't like it for whatever reason, so I'll leave it be.