### PR TITLE
[NFSC] FPS limit adjuster & proper motion blur disabler

### DIFF
--- a/data/NFSCarbon.WidescreenFix/scripts/NFSCarbon.WidescreenFix.ini
+++ b/data/NFSCarbon.WidescreenFix/scripts/NFSCarbon.WidescreenFix.ini
@@ -16,5 +16,6 @@ CustomUserFilesDirectoryInGameDir = 0    // User files will be stored in a speci
 WriteSettingsToFile = 0                  // All registry settings will be saved to "settings.ini" in your profile folder. You must input your CD key and langauge in "settings.ini" when this option is enabled.
 CrashFix = 1                             // Solves an issue that caused the game to crash after loading a profile.
 ImproveGamepadSupport = 0                // Replaces keyboard icons with gamepad icons and assigns front-end actions. Requires an XInput gamepad. (1 = Xbox Icons | 2 = PlayStation Icons | 3 = None)
+FPSLimit = 60                            // Allows users to control the framerate limit.
 ExpandControllerOptions = 0              // Lists all 29 options in the controller config menu. Will only work with new profiles, existing profiles will crash.
 LeftStickDeadzone = 10.0                 // Controls the deadzone of the left analog stick.

--- a/data/NFSCarbon.WidescreenFix/scripts/NFSCarbon.WidescreenFix.ini
+++ b/data/NFSCarbon.WidescreenFix/scripts/NFSCarbon.WidescreenFix.ini
@@ -17,5 +17,6 @@ WriteSettingsToFile = 0                  // All registry settings will be saved 
 CrashFix = 1                             // Solves an issue that caused the game to crash after loading a profile.
 ImproveGamepadSupport = 0                // Replaces keyboard icons with gamepad icons and assigns front-end actions. Requires an XInput gamepad. (1 = Xbox Icons | 2 = PlayStation Icons | 3 = None)
 FPSLimit = 60                            // Allows users to control the framerate limit.
+DisableMotionBlur = 0                    // Allows users to disable motion blur without changing registry settings and without losing other effects (such as screen flashes or light trails).
 ExpandControllerOptions = 0              // Lists all 29 options in the controller config menu. Will only work with new profiles, existing profiles will crash.
 LeftStickDeadzone = 10.0                 // Controls the deadzone of the left analog stick.

--- a/readme.md
+++ b/readme.md
@@ -852,6 +852,8 @@ The usage is as simple as inserting the files into game's root directory. Uninst
 
 ![](https://habrastorage.org/webt/d_/eg/ym/d_egymd6w_tem2erocab-e9ikna.png) Added an option to improve gamepad support (gamepad icons, fixed bindings etc)
 
+![](https://habrastorage.org/webt/d_/eg/ym/d_egymd6w_tem2erocab-e9ikna.png) Added an option to change fps limit
+
 ![](https://habrastorage.org/webt/d_/eg/ym/d_egymd6w_tem2erocab-e9ikna.png) Added an option to expand controller configuration
 
 ![](https://habrastorage.org/webt/d_/eg/ym/d_egymd6w_tem2erocab-e9ikna.png) Added an option to increase deadzone for left stick

--- a/readme.md
+++ b/readme.md
@@ -852,6 +852,8 @@ The usage is as simple as inserting the files into game's root directory. Uninst
 
 ![](https://habrastorage.org/webt/d_/eg/ym/d_egymd6w_tem2erocab-e9ikna.png) Added an option to improve gamepad support (gamepad icons, fixed bindings etc)
 
+![](https://habrastorage.org/webt/d_/eg/ym/d_egymd6w_tem2erocab-e9ikna.png) Added an option to disable motion blur
+
 ![](https://habrastorage.org/webt/d_/eg/ym/d_egymd6w_tem2erocab-e9ikna.png) Added an option to change fps limit
 
 ![](https://habrastorage.org/webt/d_/eg/ym/d_egymd6w_tem2erocab-e9ikna.png) Added an option to expand controller configuration

--- a/readme.md
+++ b/readme.md
@@ -852,7 +852,7 @@ The usage is as simple as inserting the files into game's root directory. Uninst
 
 ![](https://habrastorage.org/webt/d_/eg/ym/d_egymd6w_tem2erocab-e9ikna.png) Added an option to improve gamepad support (gamepad icons, fixed bindings etc)
 
-![](https://habrastorage.org/webt/d_/eg/ym/d_egymd6w_tem2erocab-e9ikna.png) Added an option to disable motion blur
+![](https://habrastorage.org/webt/d_/eg/ym/d_egymd6w_tem2erocab-e9ikna.png) Added an option to disable motion blur without losing other effects
 
 ![](https://habrastorage.org/webt/d_/eg/ym/d_egymd6w_tem2erocab-e9ikna.png) Added an option to change fps limit
 

--- a/source/NFSCarbon.WidescreenFix/dllmain.cpp
+++ b/source/NFSCarbon.WidescreenFix/dllmain.cpp
@@ -33,6 +33,7 @@ void Init()
     bool bExpandControllerOptions = iniReader.ReadInteger("MISC", "ExpandControllerOptions", 0) != 0;
     static float fLeftStickDeadzone = iniReader.ReadFloat("MISC", "LeftStickDeadzone", 10.0f);
     static float fRainDropletsScale = iniReader.ReadFloat("MISC", "RainDropletsScale", 0.5f);
+    bool bDisableMotionBlur = iniReader.ReadInteger("MISC", "DisableMotionBlur", 0) != 0;
     static int nFPSLimit = iniReader.ReadInteger("MISC", "FPSLimit", 60);
     if (szCustomUserFilesDirectoryInGameDir.empty() || szCustomUserFilesDirectoryInGameDir == "0")
         szCustomUserFilesDirectoryInGameDir.clear();
@@ -378,6 +379,12 @@ void Init()
             injector::MakeCALL((uint32_t)dword_6CBF17, static_cast<HRESULT(WINAPI*)(HWND, int, HANDLE, DWORD, LPSTR)>(SHGetFolderPathAHook), true);
             injector::MakeNOP((uint32_t)dword_6CBF17 + 5, 1, true);
         }
+    }
+
+    if (bDisableMotionBlur)
+    {
+        uint32_t* dword_71356B = hook::pattern("D9 87 B4 00 00 00 D8 1D ? ? ? ? DF E0 F6 C4 41 75 76").count(1).get(0).get<uint32_t>(17); //0x0071355A
+        injector::WriteMemory<uint8_t>(dword_71356B, 0xEB, true);
     }
 
     if (nWindowedMode)

--- a/source/NFSUnderground.WidescreenFix/dllmain.cpp
+++ b/source/NFSUnderground.WidescreenFix/dllmain.cpp
@@ -354,7 +354,7 @@ void Init()
     static auto szCustomUserFilesDirectoryInGameDir = iniReader.ReadString("MISC", "CustomUserFilesDirectoryInGameDir", "0");
     static int nImproveGamepadSupport = iniReader.ReadInteger("MISC", "ImproveGamepadSupport", 0);
     static float fLeftStickDeadzone = iniReader.ReadFloat("MISC", "LeftStickDeadzone", 10.0f);
-    static int nFPSLimit = iniReader.ReadInteger("MISC", "FPSLimit", 120);
+    static int nFPSLimit = iniReader.ReadInteger("MISC", "FPSLimit", 60);
     int nHideDebugObjects = iniReader.ReadInteger("MISC", "HideDebugObjects", 0);
     bool bBlackMagazineFix = iniReader.ReadInteger("MISC", "BlackMagazineFix", 0) != 0;
     if (szCustomUserFilesDirectoryInGameDir.empty() || szCustomUserFilesDirectoryInGameDir == "0")


### PR DESCRIPTION
(also fixed the default inireader value for NFSU FPS limit)

- sim can now run at any framerate
- motion blur can now be explicitly disabled (meaning: without affecting other effects such as screen flashes or light trails)