### PR TITLE
[NFSPS] implement frametime/framerate adjusters

### DIFF
--- a/data/NFSProStreet.GenericFix/scripts/NFSProStreet.GenericFix.ini
+++ b/data/NFSProStreet.GenericFix/scripts/NFSProStreet.GenericFix.ini
@@ -18,6 +18,7 @@ CustomUserFilesDirectoryInGameDir = 0    // User files will be stored in a speci
 WriteSettingsToFile = 0                  // All registry settings will be saved to "settings.ini" in your profile folder. You must input your CD key and langauge in "settings.ini" when this option is enabled.
 ImproveGamepadSupport = 0                // Replaces keyboard icons with gamepad icons and assigns front-end actions. Requires an XInput gamepad. (1 = Xbox Icons | 2 = PlayStation Icons | 3 = None)
 LeftStickDeadzone = 10.0                 // Controls the deadzone of the left analog stick.
+FPSLimit = 60                            // Allows users to control the framerate limit.
 DisableMotionBlur = 0                    // Disables motion blur without affecting the World FX setting.
 BrakeLightFix = 1                        // Solves an issue that caused brake lights to only work when ABS was active.
 GammaFix = 1                             // Solves an issue that caused the wrong brightness value to be used on launch.

--- a/readme.md
+++ b/readme.md
@@ -902,6 +902,8 @@ The usage is as simple as inserting the files into game's root directory. Uninst
 
 ![](https://habrastorage.org/webt/d_/eg/ym/d_egymd6w_tem2erocab-e9ikna.png) Added an option to disable motion blur
 
+![](https://habrastorage.org/webt/d_/eg/ym/d_egymd6w_tem2erocab-e9ikna.png) Added an option to change fps limit
+
 ![](https://habrastorage.org/webt/d_/eg/ym/d_egymd6w_tem2erocab-e9ikna.png) Added an option to fix brake lights
 
 ![](https://habrastorage.org/webt/d_/eg/ym/d_egymd6w_tem2erocab-e9ikna.png) Added an option to fix default gamma setting

--- a/source/NFSProStreet.GenericFix/dllmain.cpp
+++ b/source/NFSProStreet.GenericFix/dllmain.cpp
@@ -168,6 +168,7 @@ void Init()
     bool bBrakeLightFix = iniReader.ReadInteger("MISC", "BrakeLightFix", 1) != 0;
     static int32_t nShadowRes = iniReader.ReadInteger("MISC", "ShadowRes", 2048);
     static auto szCustomUserFilesDirectoryInGameDir = iniReader.ReadString("MISC", "CustomUserFilesDirectoryInGameDir", "0");
+    static int nFPSLimit = iniReader.ReadInteger("MISC", "FPSLimit", 60);
     if (szCustomUserFilesDirectoryInGameDir.empty() || szCustomUserFilesDirectoryInGameDir == "0")
         szCustomUserFilesDirectoryInGameDir.clear();
 
@@ -618,6 +619,45 @@ void Init()
                 *(uint32_t*)(regs.esi + 0x238) = (uint32_t)(dStickState * 65535.0);
             }
         }; injector::MakeInline<DeadzoneHookY>(pattern.get_first(18 + 0), pattern.get_first(18 + 6));
+    }
+
+    if (nFPSLimit)
+    {
+        static float FrameTime = 1.0f / nFPSLimit;
+        static double dFrameTime = 1.0 / nFPSLimit;
+        //static float fnFPSLimit = (float)nFPSLimit;
+        static double dnFPSLimit = (double)nFPSLimit;
+
+        // Frame times
+        // PrepareRealTimestep() NTSC video mode framerate, .text
+        uint32_t* dword_6D8B8F = hook::pattern("D9 05 ? ? ? ? B9 ? ? ? ? D8 44 24 14 D9 5C 24 14").count(1).get(0).get<uint32_t>(53); //0x6D8B5A anchor, 0x6D8B8F pointer write
+        // MainLoop double frametime (FPS lock) .rdata
+        double* dbl_9FABF8 = *hook::pattern("D8 44 24 08 D9 5C 24 20 EB 47 83 3D").count(1).get(0).get<double*>(0x1B); //0x006DAEE8 anchor, 0x6DAF03 location dereference
+        // MainLoop float frametime (FPS lock) .rdata
+        float* flt_98C218 = *hook::pattern("D8 44 24 08 D9 5C 24 20 EB 47 83 3D").count(1).get(0).get<float*>(0x30); //0x006DAEE8 anchor, 0x6DAF18 location dereference
+        // FullSpeedMode frametime (10x speed) .rdata
+        float* flt_98D868 = *hook::pattern("D8 44 24 08 D9 5C 24 20 EB 47 83 3D").count(1).get(0).get<float*>(0x47); //0x006DAEE8 anchor, 0x6DAF2F location dereference
+        // Unknown frametime 1 .rdata
+        float* flt_996F48 = *hook::pattern("D8 66 7C D9 5C 24 14 D9 44 24 14 D9 05 ? ? ? ? DF F1").count(1).get(0).get<float*>(0xD); //0x74F3F4 anchor, 0x74F401 location dereference
+        // Unknown frametime 2 .rdata
+        double* dbl_996F40 = *hook::pattern("D8 66 7C D9 5C 24 14 D9 44 24 14 D9 05 ? ? ? ? DF F1").count(1).get(0).get<double*>(0x33); //0x74F3F4 anchor, 0x74F427 location dereference
+        // Unknown frametime 3 .rdata
+        float* flt_996F3C = *hook::pattern("D8 66 7C D9 5C 24 14 D9 44 24 14 D9 05 ? ? ? ? DF F1").count(1).get(0).get<float*>(0x41); //0x74F3F4 anchor, 0x0074F435 location dereference
+        // Sim::QueueEvents frametime .rdata (this affects gameplay smoothness noticeably)
+        float* flt_9EE934 = *hook::pattern("D9 46 1C 8B 10 83 EC 08 D9 5C 24 04 8B C8 D9 05 ? ? ? ?").count(1).get(0).get<float*>(16); //0x004CE576 anchor, 0x004CE586 location dereference
+
+        injector::WriteMemory(dword_6D8B8F, &dnFPSLimit, true);
+        injector::WriteMemory(dbl_9FABF8, dFrameTime, true);
+        injector::WriteMemory(flt_98C218, FrameTime, true);
+        injector::WriteMemory(flt_98D868, FrameTime * 10.0f, true);
+        injector::WriteMemory(flt_996F48, FrameTime, true);
+        injector::WriteMemory(dbl_996F40, -dFrameTime, true);
+        injector::WriteMemory(flt_996F3C, -FrameTime, true);
+        injector::WriteMemory(flt_9EE934, FrameTime, true);
+
+        // Frame rates
+        // TODO: if any issues arise, figure out where 60.0 values are used and update the constants...
+        // TODO: DRAG BURNOUT -- it's way too easy to get grip when the framerate is high! (DragStaging, DragStagingMeter)
     }
 
     if (bWriteSettingsToFile)


### PR DESCRIPTION
Same as others, you can adjust frametime of the Sim and the renderer.

Also included is a workaround for the boost grip gain - this value needs to scale with the framerate/frametime, otherwise the grip addition becomes too big and therefore the drag staging (burnout) becomes way too easy to do and you gain max grip super fast.

Probably the proper way to fix this would be to make these values dynamically change with the frametime currently on the screen.

Yes, this is technically a _gameplay_ modification included in here, but it's for the sake of fixing it caused by high FPS.