### PR TITLE
[NFSMW/C] avoid other time scalars

### DIFF
--- a/source/NFSCarbon.WidescreenFix/dllmain.cpp
+++ b/source/NFSCarbon.WidescreenFix/dllmain.cpp
@@ -682,7 +682,8 @@ void Init()
 
         // Frame times
         // PrepareRealTimestep() NTSC video mode frametime, .rdata
-        float* flt_9CBC14 = *hook::pattern("D9 05 ? ? ? ? B9 ? ? ? ? D8 44 24 14 D9 5C 24 14").count(1).get(0).get<float*>(53); //0x006B4CFB
+        //float* flt_9CBC14 = *hook::pattern("D9 05 ? ? ? ? B9 ? ? ? ? D8 44 24 14 D9 5C 24 14").count(1).get(0).get<float*>(53); //0x006B4CFB
+        uint32_t* dword_6B4D30 = hook::pattern("D9 05 ? ? ? ? B9 ? ? ? ? D8 44 24 14 D9 5C 24 14").count(1).get(0).get<uint32_t>(53); //0x006B4CFB
         // MainLoop frametime (FPS lock) .text
         float* flt_6B79E3 = hook::pattern("C7 44 24 1C 89 88 88 3C").count(1).get(0).get<float>(4); //0x6B79DF
         // FullSpeedMode frametime (10x speed) .text
@@ -698,7 +699,8 @@ void Init()
         // Sim::QueueEvents frametime .text (this affects gameplay smoothness noticeably)
         float* flt_9EBB6C = *hook::pattern("D9 46 1C 8B 46 24 83 F8 03 D8 0D ? ? ? ?").count(1).get(0).get<float*>(11); //0x0076AD57
 
-        injector::WriteMemory(flt_9CBC14, FrameTime, true);
+        //injector::WriteMemory(flt_9CBC14, FrameTime, true);
+        injector::WriteMemory(dword_6B4D30, &FrameTime, true);
         injector::WriteMemory(flt_6B79E3, FrameTime, true);
         injector::WriteMemory(flt_6B79F4, FrameTime * 10.0f, true);
         injector::WriteMemory(flt_764A42, FrameTime, true);

--- a/source/NFSMostWanted.WidescreenFix/dllmain.cpp
+++ b/source/NFSMostWanted.WidescreenFix/dllmain.cpp
@@ -912,15 +912,22 @@ void Init()
 
         // Frame times
         // PrepareRealTimestep() NTSC video mode frametime .rdata
-        float* flt_8970F0 = *hook::pattern("D9 05 ? ? ? ? B9 ? ? ? ? D8 44 24 14 D9 5C 24 14").count(1).get(0).get<float*>(53); //0x006612B7
+        uint32_t* dword_6612EC = hook::pattern("D9 05 ? ? ? ? B9 ? ? ? ? D8 44 24 14 D9 5C 24 14").count(1).get(0).get<uint32_t>(53); //0x006612B7 anchor
         // MainLoop frametime .text
         float* flt_666100 = hook::pattern("E8 ? ? ? ? 68 89 88 88 3C").count(1).get(0).get<float>(6);
         // World_Service UglyTimestepHack initial state .data
         float* flt_903290 = *hook::pattern("8B 0D ? ? ? ? 85 C9 C7 05 ? ? ? ? 00 00 00 00 74 05").count(1).get(0).get<float*>(10); //0x0075AAD8 dereference
+        // GetDebugRealTime() NTSC frametime 1 .text
+        uint32_t* dword_65C78F = hook::pattern("83 EC 08 A1 ? ? ? ? 89 44 24 04 A1 ? ? ? ? 85 C0 75 08").count(1).get(0).get<uint32_t>(0x1F); //0x0065C770 anchor
+        // GetDebugRealTime() NTSC frametime 2 .text
+        uint32_t* dword_65C7D9 = hook::pattern("83 EC 08 A1 ? ? ? ? 89 44 24 04 A1 ? ? ? ? 85 C0 75 08").count(1).get(0).get<uint32_t>(0x69); //0x0065C770 anchor
 
-        injector::WriteMemory(flt_8970F0, FrameTime, true);
+        injector::WriteMemory(dword_6612EC, &FrameTime, true);
+        //injector::WriteMemory(flt_8970F0, FrameTime, true);
         injector::WriteMemory(flt_666100, FrameTime, true);
         *flt_903290 = FrameTime;
+        injector::WriteMemory(dword_65C78F, &FrameTime, true);
+        injector::WriteMemory(dword_65C7D9, &FrameTime, true);
 
         // Frame rates
         // TODO: if any issues arise, figure out where 60.0 values are used and update the constants...


### PR DESCRIPTION
Bugfix for MW and Carbon - 1/60 value was shared for other things in the game, not just frametime, so this makes it apply only to the timestep values and nothing else.

This fixes the wrong time text in Challenge Series menus.