### PR TITLE
[NFS] clarify disabled state for FPSLimit

### DIFF
--- a/data/NFSCarbon.WidescreenFix/scripts/NFSCarbon.WidescreenFix.ini
+++ b/data/NFSCarbon.WidescreenFix/scripts/NFSCarbon.WidescreenFix.ini
@@ -16,7 +16,7 @@ CustomUserFilesDirectoryInGameDir = 0    // User files will be stored in a speci
 WriteSettingsToFile = 0                  // All registry settings will be saved to "settings.ini" in your profile folder. You must input your CD key and langauge in "settings.ini" when this option is enabled.
 CrashFix = 1                             // Solves an issue that caused the game to crash after loading a profile.
 ImproveGamepadSupport = 0                // Replaces keyboard icons with gamepad icons and assigns front-end actions. Requires an XInput gamepad. (1 = Xbox Icons | 2 = PlayStation Icons | 3 = None)
-FPSLimit = 60                            // Allows users to control the framerate limit. (60 = Default | 0 = Disabled | -1 = Primary monitor refresh rate)
+FPSLimit = 60                            // Allows users to control the framerate limit. (60 = Default | 0 = Disable patches | -1 = Primary monitor refresh rate)
 DisableMotionBlur = 0                    // Allows users to disable motion blur without changing registry settings and without losing other effects (such as screen flashes or light trails).
 ExpandControllerOptions = 0              // Lists all 29 options in the controller config menu. Will only work with new profiles, existing profiles will crash.
 LeftStickDeadzone = 10.0                 // Controls the deadzone of the left analog stick.

--- a/data/NFSMostWanted.WidescreenFix/scripts/NFSMostWanted.WidescreenFix.ini
+++ b/data/NFSMostWanted.WidescreenFix/scripts/NFSMostWanted.WidescreenFix.ini
@@ -18,7 +18,7 @@ ForceEnableMirror = 1                    // Rearview mirror will be visible for 
 CustomUserFilesDirectoryInGameDir = 0    // User files will be stored in a specified directory (for example: "save"). Use '0' to disable.
 WriteSettingsToFile = 0                  // All registry settings will be saved to "settings.ini" in your profile folder. You must input your CD key and langauge in "settings.ini" when this option is enabled.
 ImproveGamepadSupport = 0                // Replaces keyboard icons with gamepad icons and assigns front-end actions. Requires an XInput gamepad. (1 = Xbox Icons | 2 = PlayStation Icons | 3 = None)
-FPSLimit = 60                            // Allows users to control the framerate limit. (60 = Default | 0 = Disabled | -1 = Primary monitor refresh rate)
+FPSLimit = 60                            // Allows users to control the framerate limit. (60 = Default | 0 = Disable patches | -1 = Primary monitor refresh rate)
 DisableMotionBlur = 0                    // Allows users to disable motion blur without changing registry settings.
 ForceHighSpecAudio = 1                   // Enables 44100Hz sample rate audio regardless of registry settings.
 LeftStickDeadzone = 10.0                 // Controls the deadzone of the left analog stick.

--- a/data/NFSProStreet.GenericFix/scripts/NFSProStreet.GenericFix.ini
+++ b/data/NFSProStreet.GenericFix/scripts/NFSProStreet.GenericFix.ini
@@ -18,7 +18,7 @@ CustomUserFilesDirectoryInGameDir = 0    // User files will be stored in a speci
 WriteSettingsToFile = 0                  // All registry settings will be saved to "settings.ini" in your profile folder. You must input your CD key and langauge in "settings.ini" when this option is enabled.
 ImproveGamepadSupport = 0                // Replaces keyboard icons with gamepad icons and assigns front-end actions. Requires an XInput gamepad. (1 = Xbox Icons | 2 = PlayStation Icons | 3 = None)
 LeftStickDeadzone = 10.0                 // Controls the deadzone of the left analog stick.
-FPSLimit = 60                            // Allows users to control the framerate limit. (60 = Default | 0 = Disabled | -1 = Primary monitor refresh rate)
+FPSLimit = 60                            // Allows users to control the framerate limit. (60 = Default | 0 = Disable patches | -1 = Primary monitor refresh rate)
 DisableMotionBlur = 0                    // Disables motion blur without affecting the World FX setting.
 BrakeLightFix = 1                        // Solves an issue that caused brake lights to only work when ABS was active.
 GammaFix = 1                             // Solves an issue that caused the wrong brightness value to be used on launch.

--- a/data/NFSUndercover.GenericFix/scripts/NFSUndercover.GenericFix.ini
+++ b/data/NFSUndercover.GenericFix/scripts/NFSUndercover.GenericFix.ini
@@ -20,5 +20,5 @@ CSMScaleNear = 100.0                     // Nearest cascade (100.0 = Default | 5
 CSMScaleMid = 175.0                      // Mid cascade (175.0 = Default | 30.0 = Game Default)
 CSMScaleFar = 300.0                      // Far cascade (300.0 = Default | 170.0 = Game Default)
 ImproveSceneryLOD = 1                    // Increases visible scenery on screen.
-FPSLimit = 60                            // Allows users to control the framerate limit. (60 = Default | 0 = Disabled | -1 = Primary monitor refresh rate)
+FPSLimit = 60                            // Allows users to control the framerate limit. (60 = Default | 0 = Disable patches | -1 = Primary monitor refresh rate)
 DisableMotionBlur = 0                    // Disables motion blur without affecting the World FX setting.

--- a/data/NFSUnderground.WidescreenFix/scripts/NFSUnderground.WidescreenFix.ini
+++ b/data/NFSUnderground.WidescreenFix/scripts/NFSUnderground.WidescreenFix.ini
@@ -13,6 +13,6 @@ WindowedMode = 0                         // 1 activates borderless windowed mode
 HideDebugObjects = 1                     // Hides debug objects. (1 = Removed by code | 2 = Adds borders to the front-end)
 CustomUserFilesDirectoryInGameDir = 0    // User files will be stored in a specified directory (for example: "save"). Use '0' to disable.
 ImproveGamepadSupport = 0                // Replaces keyboard icons with gamepad icons and assigns front-end actions. Requires an XInput gamepad. (1 = Xbox Icons | 2 = PlayStation Icons | 3 = None)
-FPSLimit = 60                            // Allows users to control the framerate limit. (60 = Default | 0 = Disabled | -1 = Primary monitor refresh rate)
+FPSLimit = 60                            // Allows users to control the framerate limit. (60 = Default | 0 = Disable patches | -1 = Primary monitor refresh rate)
 BlackMagazineFix = 0                     // Fixes black background in magazine covers. May not be compatible with all versions of the game.
 LeftStickDeadzone = 10.0                 // Controls the deadzone of the left analog stick.

--- a/data/NFSUnderground2.WidescreenFix/scripts/NFSUnderground2.WidescreenFix.ini
+++ b/data/NFSUnderground2.WidescreenFix/scripts/NFSUnderground2.WidescreenFix.ini
@@ -14,7 +14,7 @@ DisableCutsceneBorders = 1               // Removes letterboxing that appears du
 CustomUserFilesDirectoryInGameDir = 0    // User files will be stored in a specified directory (for example: "save"). Use '0' to disable.
 WriteSettingsToFile = 0                  // All registry settings will be saved to "settings.ini" in your profile folder. You must input your CD key and langauge in "settings.ini" when this option is enabled.
 ImproveGamepadSupport = 0                // Adds text to buttons and assigns front-end actions. Requires an XInput gamepad. (1 = Xbox Text | 2 = PlayStation Text | 3 = PC Text | 4 = None)
-FPSLimit = 120                           // Allows users to control the framerate limit. (120 = Default | 0 = Disabled | -1 = Primary monitor refresh rate)
+FPSLimit = 120                           // Allows users to control the framerate limit. (120 = Default | 0 = Disable patches | -1 = Primary monitor refresh rate)
 60FPSCutscenes = 1                       // Increases the framerate limit for cutscenes to 60.
 SingleCoreAffinity = 1                   // Limits game to one CPU core to prevent crashing.
 LeftStickDeadzone = 10.0                 // Controls the deadzone of the left analog stick.


### PR DESCRIPTION
Added extra clarification to ini

0 isn't disabled limiter, but is disabling the patches

Limiter itself can be "disabled" but probably in a very specific way (sim engine still needs to tick).