### PR TITLE
Various improvements and fixes

### DIFF
--- a/data/NFSCarbon.WidescreenFix/scripts/NFSCarbon.WidescreenFix.ini
+++ b/data/NFSCarbon.WidescreenFix/scripts/NFSCarbon.WidescreenFix.ini
@@ -9,7 +9,7 @@ FMVWidescreenMode = 1                    // FMVs will appear in fullscreen for 1
 
 [MISC]
 SkipIntro = 0                            // Skips FMVs that play when you launch the game.
-WindowedMode = 0                         // Enables windowed mode. (1 = Borderless | 2 = Border)
+WindowedMode = 0                         // Enables windowed mode. (1 = Borderless | 2 = Border | 3 = Border with resizing)
 LightingFix = 1                          // Adjusts lighting to match the Xbox 360 version.
 CarShadowFix = 1                         // Reduces shadow opacity to match the Xbox 360 version.
 CustomUserFilesDirectoryInGameDir = 0    // User files will be stored in a specified directory (for example: "save"). Use '0' to disable.

--- a/data/NFSProStreet.GenericFix/scripts/NFSProStreet.GenericFix.ini
+++ b/data/NFSProStreet.GenericFix/scripts/NFSProStreet.GenericFix.ini
@@ -13,7 +13,7 @@ ConsoleHUDSize = 0                       // Makes the HUD smaller like the conso
 
 [MISC]
 SkipIntro = 0                            // Skips FMVs that play when you launch the game.
-WindowedMode = 0                         // Enables windowed mode. (1 = Borderless | 2 = Border)
+WindowedMode = 0                         // Enables windowed mode. (1 = Borderless | 2 = Border | 3 = Border with resizing)
 CustomUserFilesDirectoryInGameDir = 0    // User files will be stored in a specified directory (for example: "save"). Use '0' to disable.
 WriteSettingsToFile = 0                  // All registry settings will be saved to "settings.ini" in your profile folder. You must input your CD key and langauge in "settings.ini" when this option is enabled.
 ImproveGamepadSupport = 0                // Replaces keyboard icons with gamepad icons and assigns front-end actions. Requires an XInput gamepad. (1 = Xbox Icons | 2 = PlayStation Icons | 3 = None)

--- a/data/NFSUndercover.GenericFix/scripts/NFSUndercover.GenericFix.ini
+++ b/data/NFSUndercover.GenericFix/scripts/NFSUndercover.GenericFix.ini
@@ -6,7 +6,7 @@ Scaling = 0                              // Adjusts FOV scaling to be proportion
 
 [MISC]
 SkipIntro = 0                            // Skips FMVs that play when you launch the game.
-WindowedMode = 0                         // Enables windowed mode. (1 = Borderless | 2 = Border)
+WindowedMode = 0                         // Enables windowed mode. (1 = Borderless | 2 = Border | 3 = Border with resizing)
 CustomUserFilesDirectoryInGameDir = 0    // User files will be stored in a specified directory (for example: "save"). Use '0' to disable.
 WriteSettingsToFile = 0                  // All registry settings will be saved to "settings.ini" in your profile folder. You must input your CD key and langauge in "settings.ini" when this option is enabled.
 ImproveGamepadSupport = 0                // Replaces keyboard icons with gamepad icons and assigns front-end actions. Requires an XInput gamepad. (1 = Xbox Icons | 2 = PlayStation Icons | 3 = None)

--- a/data/NFSUndercover.GenericFix/scripts/NFSUndercover.GenericFix.ini
+++ b/data/NFSUndercover.GenericFix/scripts/NFSUndercover.GenericFix.ini
@@ -19,6 +19,8 @@ CSMScale = 1.0                           // Overall scale of the cascade shadow 
 CSMScaleNear = 100.0                     // Nearest cascade (100.0 = Default | 5.0 = Game Default)
 CSMScaleMid = 175.0                      // Mid cascade (175.0 = Default | 30.0 = Game Default)
 CSMScaleFar = 300.0                      // Far cascade (300.0 = Default | 170.0 = Game Default)
-ImproveSceneryLOD = 1                    // Increases visible scenery on screen.
+ImproveSceneryLOD = 0                    // Increases visible scenery on screen. Increases visible scenery in the closest map section, but may cause flickering for the farther ones.
+DisablePreculler = 0                     // Disables the preculler. (precalculated culling)
+BruteforceCulling = 0                    // Forces the game to use bruteforced culling type instead of TreeCull. This can decrease culled scenery (especially out of bounds), but may increase flicker.
 FPSLimit = 60                            // Allows users to control the framerate limit. (60 = Default | 0 = Disable patches | -1 = Primary monitor refresh rate)
 DisableMotionBlur = 0                    // Disables motion blur without affecting the World FX setting.

--- a/source/NFSCarbon.WidescreenFix/dllmain.cpp
+++ b/source/NFSCarbon.WidescreenFix/dllmain.cpp
@@ -12,6 +12,50 @@ struct Screen
     float fHudPosX;
 } Screen;
 
+bool bBorderlessWindowed = true;
+bool bEnableWindowResize = false;
+HWND GameHWND = NULL;
+
+BOOL WINAPI AdjustWindowRect_Hook(LPRECT lpRect, DWORD dwStyle, BOOL bMenu)
+{
+    DWORD newStyle = 0;
+
+    if (!bBorderlessWindowed)
+        newStyle = WS_CAPTION;
+
+    return AdjustWindowRect(lpRect, newStyle, bMenu);
+}
+
+HWND WINAPI CreateWindowExA_Hook(DWORD dwExStyle, LPCSTR lpClassName, LPCSTR lpWindowName, DWORD dwStyle, int X, int Y, int nWidth, int nHeight, HWND hWndParent, HMENU hMenu, HINSTANCE hInstance, LPVOID lpParam)
+{
+    // fix the window to open at the center of the screen...
+    int DesktopX = 0;
+    int DesktopY = 0;
+
+    std::tie(DesktopX, DesktopY) = GetDesktopRes();
+
+    int WindowPosX = (int)(((float)DesktopX / 2.0f) - ((float)nWidth / 2.0f));
+    int WindowPosY = (int)(((float)DesktopY / 2.0f) - ((float)nHeight / 2.0f));
+
+    GameHWND = CreateWindowExA(dwExStyle, lpClassName, lpWindowName, 0, WindowPosX, WindowPosY, nWidth, nHeight, hWndParent, hMenu, hInstance, lpParam);
+    LONG lStyle = GetWindowLong(GameHWND, GWL_STYLE);
+
+    if (bBorderlessWindowed)
+        lStyle &= ~(WS_CAPTION | WS_THICKFRAME | WS_MINIMIZEBOX | WS_MAXIMIZEBOX | WS_SYSMENU);
+    else
+    {
+        lStyle |= (WS_MINIMIZEBOX | WS_SYSMENU);
+        if (bEnableWindowResize)
+            lStyle |= (WS_MAXIMIZEBOX | WS_THICKFRAME);
+    }
+
+    SetWindowLong(GameHWND, GWL_STYLE, lStyle);
+
+    SetWindowPos(GameHWND, 0, 0, 0, 0, 0, SWP_NOSIZE | SWP_NOMOVE | SWP_NOZORDER | SWP_FRAMECHANGED);
+
+    return GameHWND;
+}
+
 void Init()
 {
     CIniReader iniReader("");
@@ -389,46 +433,28 @@ void Init()
 
     if (nWindowedMode)
     {
-        int32_t DesktopX = 0;
-        int32_t DesktopY = 0;
-        std::tie(DesktopX, DesktopY) = GetDesktopRes();
+        pattern = hook::pattern("68 06 2D 05 54 68 06 2D 05 54 E8 ? ? ? ? 83 C4 08 50"); //0x730A07 anchor
+        uint32_t* dword_730A7B = pattern.count(1).get(0).get<uint32_t>(0x74);
+        uint32_t* dword_730A1F = pattern.count(1).get(0).get<uint32_t>(0x18);
+        uint32_t* dword_730B82 = pattern.count(1).get(0).get<uint32_t>(0x17B);
+        uint32_t* dword_730B90 = pattern.count(1).get(0).get<uint32_t>(0x189);
+        uint32_t* WindowedMode_AB0AD4 = *hook::pattern("8B 4C 24 28 8B 44 24 30 8B 7C 24 2C 8B 54 24 24 2B C1 8B 0D ? ? ? ? 2B FA").count(1).get(0).get<uint32_t*>(0x14); //0x7315F1 anchor, 0x731605 dereference
+        // note: searching some of the patterns in a different build (arcade version) yields no results... functions are slightly different because they were compiled with different compilers and settings, perhaps a more universal pattern could be made?
 
-        static tagRECT REKT;
-        REKT.left = (LONG)(((float)DesktopX / 2.0f) - ((float)Screen.Width / 2.0f));
-        REKT.top = (LONG)(((float)DesktopY / 2.0f) - ((float)Screen.Height / 2.0f));
-        REKT.right = (LONG)(REKT.left + Screen.Width);
-        REKT.bottom = (LONG)(REKT.top + Screen.Height);
-
-        auto pattern = hook::pattern("A1 ? ? ? ? 33 FF 3B C7 74"); //0xAB0AD4
-        injector::WriteMemory(*pattern.count(3).get(2).get<uint32_t*>(1), 1, true);
-
-        pattern = hook::pattern("B8 64 00 00 00 89 44 24 28"); //0x7309B4
-        injector::MakeNOP(pattern.count(1).get(0).get<uint32_t>(27), 3, true);
-        struct WindowedMode
-        {
-            void operator()(injector::reg_pack& regs)
-            {
-                *(uint32_t*)(regs.esp + 0x28) = REKT.left;
-                *(uint32_t*)(regs.esp + 0x2C) = REKT.top;
-                regs.eax = REKT.right;
-                regs.ecx = REKT.bottom;
-            }
-        }; injector::MakeInline<WindowedMode>(pattern.get_first(0), pattern.get_first(16));
+        // skip SetWindowLong because it messes things up
+        injector::MakeJMP(dword_730B82, dword_730B90, true);
+        // hook the offending functions
+        injector::MakeNOP(dword_730A7B, 6, true);
+        injector::MakeCALL(dword_730A7B, CreateWindowExA_Hook, true);
+        injector::MakeNOP(dword_730A1F, 6, true);
+        injector::MakeCALL(dword_730A1F, AdjustWindowRect_Hook, true);
+        // enable windowed mode variable
+        *WindowedMode_AB0AD4 = 1;
 
         if (nWindowedMode > 1)
-        {
-            auto SetWindowLongHook = [](HWND hWndl, int nIndex, LONG dwNewLong)
-            {
-                dwNewLong |= WS_CAPTION | WS_MINIMIZEBOX | WS_SYSMENU;
-
-                SetWindowLong(hWndl, nIndex, dwNewLong);
-                SetWindowPos(hWndl, 0, 0, 0, 0, 0, SWP_NOSIZE | SWP_NOMOVE | SWP_NOZORDER | SWP_FRAMECHANGED);
-            };
-
-            auto pattern = hook::pattern("68 00 00 00 10 6A F0 50"); //0x730B8A
-            injector::MakeNOP(pattern.get_first(8), 6, true);
-            injector::MakeCALL(pattern.get_first(8), static_cast<void(WINAPI*)(HWND, int, LONG)>(SetWindowLongHook), true);
-        }
+            bBorderlessWindowed = false;
+        if (nWindowedMode > 2) // TODO: implement dynamic resizing (like in MW)
+            bEnableWindowResize = true;
     }
 
     if (bSkipIntro)

--- a/source/NFSMostWanted.WidescreenFix/dllmain.cpp
+++ b/source/NFSMostWanted.WidescreenFix/dllmain.cpp
@@ -13,8 +13,6 @@ struct Screen
     float fShadowRatio;
 } Screen;
 
-bool bBorderlessWindowed = true;
-bool bEnableWindowResize = false;
 bool bIsResizing = false;
 bool bFixHUD = true;
 bool bFixFOV = true;
@@ -69,47 +67,6 @@ void __stdcall RacingResolution_Hook(int *width, int *height)
 {
     *width = Screen.Width;
     *height = Screen.Height;
-}
-
-BOOL WINAPI AdjustWindowRect_Hook(LPRECT lpRect, DWORD dwStyle, BOOL bMenu)
-{
-    DWORD newStyle = 0;
-
-    if (!bBorderlessWindowed)
-        newStyle = WS_CAPTION;
-
-    return AdjustWindowRect(lpRect, newStyle, bMenu);
-}
-
-HWND WINAPI CreateWindowExA_Hook(DWORD dwExStyle, LPCSTR lpClassName, LPCSTR lpWindowName, DWORD dwStyle, int X, int Y, int nWidth, int nHeight, HWND hWndParent, HMENU hMenu, HINSTANCE hInstance, LPVOID lpParam)
-{
-    HWND GameHWND = NULL;
-
-    // fix the window to open at the center of the screen...
-    int DesktopX = 0;
-    int DesktopY = 0;
-
-    std::tie(DesktopX, DesktopY) = GetDesktopRes();
-
-    int WindowPosX = (int)(((float)DesktopX / 2.0f) - ((float)nWidth / 2.0f));
-    int WindowPosY = (int)(((float)DesktopY / 2.0f) - ((float)nHeight / 2.0f));
-
-    GameHWND = CreateWindowExA(dwExStyle, lpClassName, lpWindowName, 0, WindowPosX, WindowPosY, nWidth, nHeight, hWndParent, hMenu, hInstance, lpParam);
-    LONG lStyle = GetWindowLong(GameHWND, GWL_STYLE);
-
-    if (bBorderlessWindowed)
-        lStyle &= ~(WS_CAPTION | WS_THICKFRAME | WS_MINIMIZEBOX | WS_MAXIMIZEBOX | WS_SYSMENU);
-    else
-    {
-        lStyle |= (WS_MINIMIZEBOX | WS_SYSMENU);
-        if (bEnableWindowResize)
-            lStyle |= (WS_MAXIMIZEBOX | WS_THICKFRAME);
-    }
-
-    SetWindowLong(GameHWND, GWL_STYLE, lStyle);
-    SetWindowPos(GameHWND, 0, 0, 0, 0, 0, SWP_NOSIZE | SWP_NOMOVE | SWP_NOZORDER | SWP_FRAMECHANGED);
-
-    return GameHWND;
 }
 
 // cave at 0x6E726B - in eDisplayFrame
@@ -837,17 +794,17 @@ void Init()
         injector::MakeJMP(dword_6E6D77, dword_6E6D8A, true);
         // hook the offending functions
         injector::MakeNOP(dword_6E6C94, 6, true);
-        injector::MakeCALL(dword_6E6C94, CreateWindowExA_Hook, true);
+        injector::MakeCALL(dword_6E6C94, WindowedModeWrapper::CreateWindowExA_Hook, true);
         injector::MakeNOP(dword_6E6C3A, 6, true);
-        injector::MakeCALL(dword_6E6C3A, AdjustWindowRect_Hook, true);
+        injector::MakeCALL(dword_6E6C3A, WindowedModeWrapper::AdjustWindowRect_Hook, true);
 
         *(int*)dword_982BF0 = 1;
 
         if (nWindowedMode > 1)
-            bBorderlessWindowed = false;
+            WindowedModeWrapper::bBorderlessWindowed = false;
         if (nWindowedMode > 2)
         {
-            bEnableWindowResize = true;
+            WindowedModeWrapper::bEnableWindowResize = true;
 
             // dereference the current WndProc from the game executable and write to the function pointer (to maximize compatibility)
             uint32_t* wndproc_addr = hook::pattern("C7 44 24 44 ? ? ? ? 89 5C 24 48 89 5C 24 4C").count(1).get(0).get<uint32_t>(4);

--- a/source/NFSProStreet.GenericFix/dllmain.cpp
+++ b/source/NFSProStreet.GenericFix/dllmain.cpp
@@ -104,10 +104,10 @@ void Init()
             list2.emplace_back(r);
         }
 
-        auto pattern = hook::pattern("83 C0 08 83 F8 58 72 E8 E9 ? ? ? ? 8B 53 3C 8B 43 10");
-        injector::WriteMemory(pattern.get_first(-6), &list2[0].ResX, true); //0x0070B3EA
-        injector::WriteMemory(pattern.get_first(-14), &list2[0].ResY, true);
-        injector::WriteMemory<uint8_t>(pattern.get_first(5), 0xFFi8, true); //0x70B3F3+2
+        auto pattern = hook::pattern("83 C0 08 83 F8 58 72 E8 E9 ? ? ? ? 8B 53 3C 8B 43 10"); //0x70B3F0
+        injector::WriteMemory(pattern.get_first(-0x6), &list2[0].ResX, true); //0x70B3EA
+        injector::WriteMemory(pattern.get_first(-0xE), &list2[0].ResY, true); //0x70B3E2
+        injector::WriteMemory<uint8_t>(pattern.get_first(0x5), 0xFFi8, true); //0x70B3F5
     }
 
     // PostRaceStateManagerFix

--- a/source/NFSUndercover.GenericFix/dllmain.cpp
+++ b/source/NFSUndercover.GenericFix/dllmain.cpp
@@ -165,6 +165,30 @@ void InitRes()
     }; injector::MakeInline<GetPackedStringHook>(pattern.get_first(0));
 }
 
+void InitRes2()
+{
+    struct ScreenRes
+    {
+        uint32_t ResX;
+        uint32_t ResY;
+    };
+
+    std::vector<std::string> list;
+    GetResolutionsList(list);
+    static std::vector<ScreenRes> list2;
+    for (auto s : list)
+    {
+        ScreenRes r;
+        sscanf_s(s.c_str(), "%dx%d", &r.ResX, &r.ResY);
+        list2.emplace_back(r);
+    }
+
+    auto pattern = hook::pattern("83 C0 08 83 F8 78 72 E8 E9 ? ? ? ? 8B 56 3C 8B 46 10"); //0x753021
+    injector::WriteMemory(pattern.get_first(-0x6), &list2[0].ResX, true); //0x75301B
+    injector::WriteMemory(pattern.get_first(-0xE), &list2[0].ResY, true); //0x753013
+    injector::WriteMemory<uint8_t>(pattern.get_first(0x5), 0xFFi8, true); //0x753026
+}
+
 void Init1()
 {
     //Stop settings reset after crash
@@ -234,7 +258,10 @@ void Init2()
             if (!bOnce)
             {
                 if (bResDetect)
+                {
                     InitRes();
+                    InitRes2();
+                }
                 if (bSkipIntro)
                     *dword_12BB200 = 1;
             }

--- a/source/NFSUndercover.GenericFix/dllmain.cpp
+++ b/source/NFSUndercover.GenericFix/dllmain.cpp
@@ -823,7 +823,7 @@ void Init4()
     injector::MakeCALL(dword_780FFF, static_cast<uint32_t(__cdecl*)(uint32_t, uint32_t)>(CSMUpdateHook), true);
 
     // Scenery LOD hacks
-    bool bImproveSceneryLOD = iniReader.ReadInteger("GRAPHICS", "ImproveSceneryLOD", 1);
+    bool bImproveSceneryLOD = iniReader.ReadInteger("GRAPHICS", "ImproveSceneryLOD", 0);
     if (bImproveSceneryLOD)
     {
         // there is 1 more step left after 0xE, with this it should actually show all scenery
@@ -831,18 +831,26 @@ void Init4()
         pattern = hook::pattern("83 F8 01 C6 44 24 0F 0E");
         uint32_t* dword_82B0AA = pattern.count(1).get(0).get<uint32_t>(7);
         injector::WriteMemory<uint8_t>(dword_82B0AA, 0x0F, true);
+    }
 
+    bool bDisablePreculler = iniReader.ReadInteger("GRAPHICS", "DisablePreculler", 0);
+    if (bDisablePreculler)
+    {
+        // disable the preculler to potentially increase scenery rendered on screen (the thing that uses PrecullerBooBooScript.hoo)
+        pattern = hook::pattern("8B 6E CC D9 45 10 88 56 14 D9 5E 0C 8B 0D ? ? ? ?");
+        uint32_t* PrecullerMode = *pattern.count(1).get(0).get<uint32_t*>(14);
+        *PrecullerMode = 0;
+    }
+
+    bool bBruteforceCulling = iniReader.ReadInteger("GRAPHICS", "BruteforceCulling", 0);
+    if (bBruteforceCulling)
+    {
         // force the game to use ScenerySectionHeader::CullBruteForce and disable ScenerySectionHeader::TreeCull
         // this reduces excessive culling in the game caused by the VisibleSections in a track
         // this does NOT fix flickering scenery in shadows/reflections/weird parts of map/etc.
         pattern = hook::pattern("84 C0 57 8B CE 74 07");
         uint32_t* dword_82B03F = pattern.count(1).get(0).get<uint32_t>(5);
         injector::MakeNOP(dword_82B03F, 2, true);
-
-        // disable the preculler to potentially increase scenery rendered on screen (the thing that uses PrecullerBooBooScript.hoo)
-        pattern = hook::pattern("8B 6E CC D9 45 10 88 56 14 D9 5E 0C 8B 0D ? ? ? ?");
-        uint32_t* PrecullerMode = *pattern.count(1).get(0).get<uint32_t*>(14);
-        *PrecullerMode = 0;
     }
 
     static int nFPSLimit = iniReader.ReadInteger("GRAPHICS", "FPSLimit", 60);


### PR DESCRIPTION
- Created `WindowedModeWrapper` namespace to consolidate the windowed mode hooks into a single place - this is not only usable in NFS, but in various other games (see my [UbiTMNTHax](https://github.com/xan1242/UbiTMNTHax) - I used this exact code)
- Reimplemented all NFS games to use the WindowedModeWrapper instead - now the windows are created properly without any fuss
- NFS Undercover - broke up the scenery LOD hacks and set the defaults for them to be DISABLED - this is unfortunately buggy because of the model limitation the game imposes. The hacks unto themselves work, they increase visible scenery, but the renderer culls them away.