### PR TITLE
[NFS] update FPSLimit default to autodetect refresh rate

### DIFF
--- a/data/NFSCarbon.WidescreenFix/scripts/NFSCarbon.WidescreenFix.ini
+++ b/data/NFSCarbon.WidescreenFix/scripts/NFSCarbon.WidescreenFix.ini
@@ -16,7 +16,7 @@ CustomUserFilesDirectoryInGameDir = 0    // User files will be stored in a speci
 WriteSettingsToFile = 0                  // All registry settings will be saved to "settings.ini" in your profile folder. You must input your CD key and langauge in "settings.ini" when this option is enabled.
 CrashFix = 1                             // Solves an issue that caused the game to crash after loading a profile.
 ImproveGamepadSupport = 0                // Replaces keyboard icons with gamepad icons and assigns front-end actions. Requires an XInput gamepad. (1 = Xbox Icons | 2 = PlayStation Icons | 3 = None)
-FPSLimit = 60                            // Allows users to control the framerate limit. (60 = Default | 0 = Disable patches | -1 = Primary monitor refresh rate)
+FPSLimit = -1                            // Allows users to control the framerate limit. (-1 = Default | 0 = Disable patches | -1 = Primary monitor refresh rate)
 DisableMotionBlur = 0                    // Allows users to disable motion blur without changing registry settings and without losing other effects (such as screen flashes or light trails).
 ExpandControllerOptions = 0              // Lists all 29 options in the controller config menu. Will only work with new profiles, existing profiles will crash.
 LeftStickDeadzone = 10.0                 // Controls the deadzone of the left analog stick.

--- a/data/NFSMostWanted.WidescreenFix/scripts/NFSMostWanted.WidescreenFix.ini
+++ b/data/NFSMostWanted.WidescreenFix/scripts/NFSMostWanted.WidescreenFix.ini
@@ -18,7 +18,7 @@ ForceEnableMirror = 1                    // Rearview mirror will be visible for 
 CustomUserFilesDirectoryInGameDir = 0    // User files will be stored in a specified directory (for example: "save"). Use '0' to disable.
 WriteSettingsToFile = 0                  // All registry settings will be saved to "settings.ini" in your profile folder. You must input your CD key and langauge in "settings.ini" when this option is enabled.
 ImproveGamepadSupport = 0                // Replaces keyboard icons with gamepad icons and assigns front-end actions. Requires an XInput gamepad. (1 = Xbox Icons | 2 = PlayStation Icons | 3 = None)
-FPSLimit = 60                            // Allows users to control the framerate limit. (60 = Default | 0 = Disable patches | -1 = Primary monitor refresh rate)
+FPSLimit = -1                            // Allows users to control the framerate limit. (-1 = Default | 0 = Disable patches | -1 = Primary monitor refresh rate)
 DisableMotionBlur = 0                    // Allows users to disable motion blur without changing registry settings.
 ForceHighSpecAudio = 1                   // Enables 44100Hz sample rate audio regardless of registry settings.
 LeftStickDeadzone = 10.0                 // Controls the deadzone of the left analog stick.

--- a/data/NFSProStreet.GenericFix/scripts/NFSProStreet.GenericFix.ini
+++ b/data/NFSProStreet.GenericFix/scripts/NFSProStreet.GenericFix.ini
@@ -18,7 +18,7 @@ CustomUserFilesDirectoryInGameDir = 0    // User files will be stored in a speci
 WriteSettingsToFile = 0                  // All registry settings will be saved to "settings.ini" in your profile folder. You must input your CD key and langauge in "settings.ini" when this option is enabled.
 ImproveGamepadSupport = 0                // Replaces keyboard icons with gamepad icons and assigns front-end actions. Requires an XInput gamepad. (1 = Xbox Icons | 2 = PlayStation Icons | 3 = None)
 LeftStickDeadzone = 10.0                 // Controls the deadzone of the left analog stick.
-FPSLimit = 60                            // Allows users to control the framerate limit. (60 = Default | 0 = Disable patches | -1 = Primary monitor refresh rate)
+FPSLimit = -1                            // Allows users to control the framerate limit. (-1 = Default | 0 = Disable patches | -1 = Primary monitor refresh rate)
 DisableMotionBlur = 0                    // Disables motion blur without affecting the World FX setting.
 BrakeLightFix = 1                        // Solves an issue that caused brake lights to only work when ABS was active.
 GammaFix = 1                             // Solves an issue that caused the wrong brightness value to be used on launch.

--- a/data/NFSUndercover.GenericFix/scripts/NFSUndercover.GenericFix.ini
+++ b/data/NFSUndercover.GenericFix/scripts/NFSUndercover.GenericFix.ini
@@ -22,5 +22,5 @@ CSMScaleFar = 300.0                      // Far cascade (300.0 = Default | 170.0
 ImproveSceneryLOD = 0                    // Increases visible scenery on screen. Increases visible scenery in the closest map section, but may cause flickering for the farther ones.
 DisablePreculler = 0                     // Disables the preculler. (precalculated culling)
 BruteforceCulling = 0                    // Forces the game to use bruteforced culling type instead of TreeCull. This can decrease culled scenery (especially out of bounds), but may increase flicker.
-FPSLimit = 60                            // Allows users to control the framerate limit. (60 = Default | 0 = Disable patches | -1 = Primary monitor refresh rate)
+FPSLimit = -1                            // Allows users to control the framerate limit. (-1 = Default | 0 = Disable patches | -1 = Primary monitor refresh rate)
 DisableMotionBlur = 0                    // Disables motion blur without affecting the World FX setting.

--- a/data/NFSUnderground.WidescreenFix/scripts/NFSUnderground.WidescreenFix.ini
+++ b/data/NFSUnderground.WidescreenFix/scripts/NFSUnderground.WidescreenFix.ini
@@ -13,6 +13,6 @@ WindowedMode = 0                         // Enables windowed mode. (1 = Borderle
 HideDebugObjects = 1                     // Hides debug objects. (1 = Removed by code | 2 = Adds borders to the front-end)
 CustomUserFilesDirectoryInGameDir = 0    // User files will be stored in a specified directory (for example: "save"). Use '0' to disable.
 ImproveGamepadSupport = 0                // Replaces keyboard icons with gamepad icons and assigns front-end actions. Requires an XInput gamepad. (1 = Xbox Icons | 2 = PlayStation Icons | 3 = None)
-FPSLimit = 60                            // Allows users to control the framerate limit. (60 = Default | 0 = Disable patches | -1 = Primary monitor refresh rate)
+FPSLimit = -1                            // Allows users to control the framerate limit. (-1 = Default | 0 = Disable patches | -1 = Primary monitor refresh rate)
 BlackMagazineFix = 0                     // Fixes black background in magazine covers. May not be compatible with all versions of the game.
 LeftStickDeadzone = 10.0                 // Controls the deadzone of the left analog stick.

--- a/data/NFSUnderground2.WidescreenFix/scripts/NFSUnderground2.WidescreenFix.ini
+++ b/data/NFSUnderground2.WidescreenFix/scripts/NFSUnderground2.WidescreenFix.ini
@@ -14,7 +14,7 @@ DisableCutsceneBorders = 1               // Removes letterboxing that appears du
 CustomUserFilesDirectoryInGameDir = 0    // User files will be stored in a specified directory (for example: "save"). Use '0' to disable.
 WriteSettingsToFile = 0                  // All registry settings will be saved to "settings.ini" in your profile folder. You must input your CD key and langauge in "settings.ini" when this option is enabled.
 ImproveGamepadSupport = 0                // Adds text to buttons and assigns front-end actions. Requires an XInput gamepad. (1 = Xbox Text | 2 = PlayStation Text | 3 = PC Text | 4 = None)
-FPSLimit = 120                           // Allows users to control the framerate limit. (120 = Default | 0 = Disable patches | -1 = Primary monitor refresh rate)
+FPSLimit = -1                            // Allows users to control the framerate limit. (-1 = Default | 0 = Disable patches | -1 = Primary monitor refresh rate)
 HighFPSCutscenes = 1                     // Increases the framerate limit for cutscenes to the nearest multiple of 30 (maximum is currently 60 due to bugs)
 SingleCoreAffinity = 1                   // Limits game to one CPU core to prevent crashing.
 LeftStickDeadzone = 10.0                 // Controls the deadzone of the left analog stick.

--- a/source/NFSCarbon.WidescreenFix/dllmain.cpp
+++ b/source/NFSCarbon.WidescreenFix/dllmain.cpp
@@ -34,7 +34,7 @@ void Init()
     static float fLeftStickDeadzone = iniReader.ReadFloat("MISC", "LeftStickDeadzone", 10.0f);
     static float fRainDropletsScale = iniReader.ReadFloat("MISC", "RainDropletsScale", 0.5f);
     bool bDisableMotionBlur = iniReader.ReadInteger("MISC", "DisableMotionBlur", 0) != 0;
-    static int nFPSLimit = iniReader.ReadInteger("MISC", "FPSLimit", 60);
+    static int nFPSLimit = iniReader.ReadInteger("MISC", "FPSLimit", -1);
     if (szCustomUserFilesDirectoryInGameDir.empty() || szCustomUserFilesDirectoryInGameDir == "0")
         szCustomUserFilesDirectoryInGameDir.clear();
 

--- a/source/NFSMostWanted.WidescreenFix/dllmain.cpp
+++ b/source/NFSMostWanted.WidescreenFix/dllmain.cpp
@@ -143,7 +143,7 @@ void Init()
     bool bForceHighSpecAudio = iniReader.ReadInteger("MISC", "ForceHighSpecAudio", 1) != 0;
     static float fLeftStickDeadzone = iniReader.ReadFloat("MISC", "LeftStickDeadzone", 10.0f);
     static float fRainDropletsScale = iniReader.ReadFloat("MISC", "RainDropletsScale", 0.5f);
-    static int nFPSLimit = iniReader.ReadInteger("MISC", "FPSLimit", 60);
+    static int nFPSLimit = iniReader.ReadInteger("MISC", "FPSLimit", -1);
     if (szCustomUserFilesDirectoryInGameDir.empty() || szCustomUserFilesDirectoryInGameDir == "0")
         szCustomUserFilesDirectoryInGameDir.clear();
     int nWindowedMode = iniReader.ReadInteger("MISC", "WindowedMode", 0);

--- a/source/NFSProStreet.GenericFix/dllmain.cpp
+++ b/source/NFSProStreet.GenericFix/dllmain.cpp
@@ -168,7 +168,7 @@ void Init()
     bool bBrakeLightFix = iniReader.ReadInteger("MISC", "BrakeLightFix", 1) != 0;
     static int32_t nShadowRes = iniReader.ReadInteger("MISC", "ShadowRes", 2048);
     static auto szCustomUserFilesDirectoryInGameDir = iniReader.ReadString("MISC", "CustomUserFilesDirectoryInGameDir", "0");
-    static int nFPSLimit = iniReader.ReadInteger("MISC", "FPSLimit", 60);
+    static int nFPSLimit = iniReader.ReadInteger("MISC", "FPSLimit", -1);
     if (szCustomUserFilesDirectoryInGameDir.empty() || szCustomUserFilesDirectoryInGameDir == "0")
         szCustomUserFilesDirectoryInGameDir.clear();
 

--- a/source/NFSUndercover.GenericFix/dllmain.cpp
+++ b/source/NFSUndercover.GenericFix/dllmain.cpp
@@ -874,7 +874,7 @@ void Init4()
         injector::MakeNOP(dword_82B03F, 2, true);
     }
 
-    static int nFPSLimit = iniReader.ReadInteger("GRAPHICS", "FPSLimit", 60);
+    static int nFPSLimit = iniReader.ReadInteger("GRAPHICS", "FPSLimit", -1);
     if (nFPSLimit)
     {
         if (nFPSLimit < 0)

--- a/source/NFSUnderground.WidescreenFix/dllmain.cpp
+++ b/source/NFSUnderground.WidescreenFix/dllmain.cpp
@@ -316,7 +316,7 @@ void Init()
     static auto szCustomUserFilesDirectoryInGameDir = iniReader.ReadString("MISC", "CustomUserFilesDirectoryInGameDir", "0");
     static int nImproveGamepadSupport = iniReader.ReadInteger("MISC", "ImproveGamepadSupport", 0);
     static float fLeftStickDeadzone = iniReader.ReadFloat("MISC", "LeftStickDeadzone", 10.0f);
-    static int nFPSLimit = iniReader.ReadInteger("MISC", "FPSLimit", 60);
+    static int nFPSLimit = iniReader.ReadInteger("MISC", "FPSLimit", -1);
     int nHideDebugObjects = iniReader.ReadInteger("MISC", "HideDebugObjects", 0);
     bool bBlackMagazineFix = iniReader.ReadInteger("MISC", "BlackMagazineFix", 0) != 0;
     if (szCustomUserFilesDirectoryInGameDir.empty() || szCustomUserFilesDirectoryInGameDir == "0")

--- a/source/NFSUnderground2.WidescreenFix/dllmain.cpp
+++ b/source/NFSUnderground2.WidescreenFix/dllmain.cpp
@@ -91,7 +91,7 @@ void Init()
     bool bWriteSettingsToFile = iniReader.ReadInteger("MISC", "WriteSettingsToFile", 1) != 0;
     static int nImproveGamepadSupport = iniReader.ReadInteger("MISC", "ImproveGamepadSupport", 0);
     static float fLeftStickDeadzone = iniReader.ReadFloat("MISC", "LeftStickDeadzone", 10.0f);
-    static int nFPSLimit= iniReader.ReadInteger("MISC", "FPSLimit", 120);
+    static int nFPSLimit= iniReader.ReadInteger("MISC", "FPSLimit", -1);
     bool bHighFPSCutscenes = iniReader.ReadInteger("MISC", "HighFPSCutscenes", 1) != 0;
     bool bSingleCoreAffinity = iniReader.ReadInteger("MISC", "SingleCoreAffinity", 0) != 0;
     bool bNoOpticalDriveFix = iniReader.ReadInteger("MISC", "NoOpticalDriveFix", 1) != 0;


### PR DESCRIPTION
- Hack is stable enough to become the default
- Fixes issues with too fast cameras, slow challenge series intros, too fast animated textures, etc.