### PR TITLE
[NFSMW+] Rename FPSLimit to SimRate

### DIFF
--- a/data/NFSCarbon.WidescreenFix/scripts/NFSCarbon.WidescreenFix.ini
+++ b/data/NFSCarbon.WidescreenFix/scripts/NFSCarbon.WidescreenFix.ini
@@ -18,5 +18,5 @@ CrashFix = 1                             // Solves an issue that caused the game
 ImproveGamepadSupport = 0                // Replaces keyboard icons with gamepad icons and assigns front-end actions. Requires an XInput gamepad. (1 = Xbox Icons | 2 = PlayStation Icons | 3 = None)
 ExpandControllerOptions = 0              // Lists all 29 options in the controller config menu. Will only work with new profiles, existing profiles will crash.
 LeftStickDeadzone = 10.0                 // Controls the deadzone of the left analog stick.
-SimRate = -1                             // Control the refresh rate of the gameplay engine. Affects overall smoothness. (-1 = Default | 0 = Disable patches | -1 = Primary monitor refresh rate | -2 = 2x primary monitor refresh | 60 = Minimum | 360 = Maximum)
+SimRate = -1                             // Control the refresh rate of the gameplay engine. Affects overall smoothness. Best to match with monitor refresh. (-1 = Default | 0 = Disable patches | -1 = Primary monitor refresh rate | -2 = 2x primary monitor refresh | 60 = Minimum | 360 = Maximum)
 DisableMotionBlur = 0                    // Allows users to disable motion blur without changing registry settings and without losing other effects (such as screen flashes or light trails).

--- a/data/NFSCarbon.WidescreenFix/scripts/NFSCarbon.WidescreenFix.ini
+++ b/data/NFSCarbon.WidescreenFix/scripts/NFSCarbon.WidescreenFix.ini
@@ -18,5 +18,5 @@ CrashFix = 1                             // Solves an issue that caused the game
 ImproveGamepadSupport = 0                // Replaces keyboard icons with gamepad icons and assigns front-end actions. Requires an XInput gamepad. (1 = Xbox Icons | 2 = PlayStation Icons | 3 = None)
 ExpandControllerOptions = 0              // Lists all 29 options in the controller config menu. Will only work with new profiles, existing profiles will crash.
 LeftStickDeadzone = 10.0                 // Controls the deadzone of the left analog stick.
-FPSLimit = -1                            // Allows users to control the framerate limit. (-1 = Default | 0 = Disable patches | -1 = Primary monitor refresh rate | -2 = 2x primary monitor refresh)
+SimRate = -1                             // Control the refresh rate of the gameplay engine. Affects overall smoothness. (-1 = Default | 0 = Disable patches | -1 = Primary monitor refresh rate | -2 = 2x primary monitor refresh | 60 = Minimum | 360 = Maximum)
 DisableMotionBlur = 0                    // Allows users to disable motion blur without changing registry settings and without losing other effects (such as screen flashes or light trails).

--- a/data/NFSMostWanted.WidescreenFix/scripts/NFSMostWanted.WidescreenFix.ini
+++ b/data/NFSMostWanted.WidescreenFix/scripts/NFSMostWanted.WidescreenFix.ini
@@ -20,5 +20,5 @@ WriteSettingsToFile = 0                  // All registry settings will be saved 
 ImproveGamepadSupport = 0                // Replaces keyboard icons with gamepad icons and assigns front-end actions. Requires an XInput gamepad. (1 = Xbox Icons | 2 = PlayStation Icons | 3 = None)
 LeftStickDeadzone = 10.0                 // Controls the deadzone of the left analog stick.
 ForceHighSpecAudio = 1                   // Enables 44100Hz sample rate audio regardless of registry settings.
-FPSLimit = -1                            // Allows users to control the framerate limit. (-1 = Default | 0 = Disable patches | -1 = Primary monitor refresh rate | -2 = 2x primary monitor refresh)
+SimRate = -1                             // Control the refresh rate of the gameplay engine. Affects overall smoothness. (-1 = Default | 0 = Disable patches | -1 = Primary monitor refresh rate | -2 = 2x primary monitor refresh | 60 = Minimum | 360 = Maximum)
 DisableMotionBlur = 0                    // Allows users to disable motion blur without changing registry settings.

--- a/data/NFSMostWanted.WidescreenFix/scripts/NFSMostWanted.WidescreenFix.ini
+++ b/data/NFSMostWanted.WidescreenFix/scripts/NFSMostWanted.WidescreenFix.ini
@@ -20,5 +20,5 @@ WriteSettingsToFile = 0                  // All registry settings will be saved 
 ImproveGamepadSupport = 0                // Replaces keyboard icons with gamepad icons and assigns front-end actions. Requires an XInput gamepad. (1 = Xbox Icons | 2 = PlayStation Icons | 3 = None)
 LeftStickDeadzone = 10.0                 // Controls the deadzone of the left analog stick.
 ForceHighSpecAudio = 1                   // Enables 44100Hz sample rate audio regardless of registry settings.
-SimRate = -1                             // Control the refresh rate of the gameplay engine. Affects overall smoothness. (-1 = Default | 0 = Disable patches | -1 = Primary monitor refresh rate | -2 = 2x primary monitor refresh | 60 = Minimum | 360 = Maximum)
+SimRate = -1                             // Control the refresh rate of the gameplay engine. Affects overall smoothness. Best to match with monitor refresh. (-1 = Default | 0 = Disable patches | -1 = Primary monitor refresh rate | -2 = 2x primary monitor refresh | 60 = Minimum | 360 = Maximum)
 DisableMotionBlur = 0                    // Allows users to disable motion blur without changing registry settings.

--- a/data/NFSProStreet.GenericFix/scripts/NFSProStreet.GenericFix.ini
+++ b/data/NFSProStreet.GenericFix/scripts/NFSProStreet.GenericFix.ini
@@ -21,5 +21,5 @@ LeftStickDeadzone = 10.0                 // Controls the deadzone of the left an
 BrakeLightFix = 1                        // Solves an issue that caused brake lights to only work when ABS was active.
 GammaFix = 1                             // Solves an issue that caused the wrong brightness value to be used on launch.
 ShadowRes = 2048                         // Controls the resolution of dynamic shadows. (2048 = Default) 
-FPSLimit = -1                            // Allows users to control the framerate limit. (-1 = Default | 0 = Disable patches | -1 = Primary monitor refresh rate | -2 = 2x primary monitor refresh)
+SimRate = -1                             // Control the refresh rate of the gameplay engine. Affects overall smoothness. (-1 = Default | 0 = Disable patches | -1 = Primary monitor refresh rate | -2 = 2x primary monitor refresh | 60 = Minimum | 360 = Maximum)
 DisableMotionBlur = 0                    // Disables motion blur without affecting the World FX setting.

--- a/data/NFSProStreet.GenericFix/scripts/NFSProStreet.GenericFix.ini
+++ b/data/NFSProStreet.GenericFix/scripts/NFSProStreet.GenericFix.ini
@@ -21,5 +21,5 @@ LeftStickDeadzone = 10.0                 // Controls the deadzone of the left an
 BrakeLightFix = 1                        // Solves an issue that caused brake lights to only work when ABS was active.
 GammaFix = 1                             // Solves an issue that caused the wrong brightness value to be used on launch.
 ShadowRes = 2048                         // Controls the resolution of dynamic shadows. (2048 = Default) 
-SimRate = -1                             // Control the refresh rate of the gameplay engine. Affects overall smoothness. (-1 = Default | 0 = Disable patches | -1 = Primary monitor refresh rate | -2 = 2x primary monitor refresh | 60 = Minimum | 360 = Maximum)
+SimRate = -1                             // Control the refresh rate of the gameplay engine. Affects overall smoothness. Best to match with monitor refresh. (-1 = Default | 0 = Disable patches | -1 = Primary monitor refresh rate | -2 = 2x primary monitor refresh | 60 = Minimum | 360 = Maximum)
 DisableMotionBlur = 0                    // Disables motion blur without affecting the World FX setting.

--- a/data/NFSUndercover.GenericFix/scripts/NFSUndercover.GenericFix.ini
+++ b/data/NFSUndercover.GenericFix/scripts/NFSUndercover.GenericFix.ini
@@ -22,5 +22,5 @@ CSMScaleFar = 300.0                      // Far cascade (300.0 = Default | 170.0
 ImproveSceneryLOD = 0                    // Increases visible scenery on screen. Increases visible scenery in the closest map section, but may cause flickering for the farther ones.
 DisablePreculler = 0                     // Disables the preculler. (precalculated culling)
 BruteforceCulling = 0                    // Forces the game to use bruteforced culling type instead of TreeCull. This can decrease culled scenery (especially out of bounds), but may increase flicker.
-FPSLimit = -1                            // Allows users to control the framerate limit. (-1 = Default | 0 = Disable patches | -1 = Primary monitor refresh rate | -2 = 2x primary monitor refresh)
+SimRate = -1                             // Control the refresh rate of the gameplay engine. Affects overall smoothness. (-1 = Default | 0 = Disable patches | -1 = Primary monitor refresh rate | -2 = 2x primary monitor refresh | 60 = Minimum | 360 = Maximum)
 DisableMotionBlur = 0                    // Disables motion blur without affecting the World FX setting.

--- a/data/NFSUndercover.GenericFix/scripts/NFSUndercover.GenericFix.ini
+++ b/data/NFSUndercover.GenericFix/scripts/NFSUndercover.GenericFix.ini
@@ -22,5 +22,5 @@ CSMScaleFar = 300.0                      // Far cascade (300.0 = Default | 170.0
 ImproveSceneryLOD = 0                    // Increases visible scenery on screen. Increases visible scenery in the closest map section, but may cause flickering for the farther ones.
 DisablePreculler = 0                     // Disables the preculler. (precalculated culling)
 BruteforceCulling = 0                    // Forces the game to use bruteforced culling type instead of TreeCull. This can decrease culled scenery (especially out of bounds), but may increase flicker.
-SimRate = -1                             // Control the refresh rate of the gameplay engine. Affects overall smoothness. (-1 = Default | 0 = Disable patches | -1 = Primary monitor refresh rate | -2 = 2x primary monitor refresh | 60 = Minimum | 360 = Maximum)
+SimRate = -1                             // Control the refresh rate of the gameplay engine. Affects overall smoothness. Best to match with monitor refresh. (-1 = Default | 0 = Disable patches | -1 = Primary monitor refresh rate | -2 = 2x primary monitor refresh | 60 = Minimum | 360 = Maximum)
 DisableMotionBlur = 0                    // Disables motion blur without affecting the World FX setting.

--- a/source/NFSMostWanted.WidescreenFix/dllmain.cpp
+++ b/source/NFSMostWanted.WidescreenFix/dllmain.cpp
@@ -143,7 +143,7 @@ void Init()
     bool bForceHighSpecAudio = iniReader.ReadInteger("MISC", "ForceHighSpecAudio", 1) != 0;
     static float fLeftStickDeadzone = iniReader.ReadFloat("MISC", "LeftStickDeadzone", 10.0f);
     static float fRainDropletsScale = iniReader.ReadFloat("MISC", "RainDropletsScale", 0.5f);
-    static int nFPSLimit = iniReader.ReadInteger("MISC", "FPSLimit", -1);
+    static int SimRate = iniReader.ReadInteger("MISC", "SimRate", -1);
     if (szCustomUserFilesDirectoryInGameDir.empty() || szCustomUserFilesDirectoryInGameDir == "0")
         szCustomUserFilesDirectoryInGameDir.clear();
     int nWindowedMode = iniReader.ReadInteger("MISC", "WindowedMode", 0);
@@ -862,20 +862,26 @@ void Init()
         }; injector::MakeInline<DeadzoneHookY>(pattern.get_first(18 + 0), pattern.get_first(18 + 6));
     }
 
-    if (nFPSLimit)
+    if (SimRate)
     {
-        if (nFPSLimit < 0)
+        if (SimRate < 0)
         {
-            if (nFPSLimit == -1)
-                nFPSLimit = GetDesktopRefreshRate();
-            else if (nFPSLimit == -2)
-                nFPSLimit = GetDesktopRefreshRate() * 2;
+            if (SimRate == -1)
+                SimRate = GetDesktopRefreshRate();
+            else if (SimRate == -2)
+                SimRate = GetDesktopRefreshRate() * 2;
             else
-                nFPSLimit = 60;
+                SimRate = 60;
         }
 
-        static float FrameTime = 1.0f / nFPSLimit;
-        //static float fnFPSLimit = (float)nFPSLimit;
+        // limit rate to avoid issues...
+        if (SimRate > 360)
+            SimRate = 360;
+        if (SimRate < 60)
+            SimRate = 60;
+
+        static float FrameTime = 1.0f / SimRate;
+        //static float fnFPSLimit = (float)SimRate;
 
         // Frame times
         // PrepareRealTimestep() NTSC video mode frametime .rdata

--- a/source/NFSUndercover.GenericFix/dllmain.cpp
+++ b/source/NFSUndercover.GenericFix/dllmain.cpp
@@ -874,23 +874,29 @@ void Init4()
         injector::MakeNOP(dword_82B03F, 2, true);
     }
 
-    static int nFPSLimit = iniReader.ReadInteger("GRAPHICS", "FPSLimit", -1);
-    if (nFPSLimit)
+    static int SimRate = iniReader.ReadInteger("GRAPHICS", "SimRate", -1);
+    if (SimRate)
     {
-        if (nFPSLimit < 0)
+        if (SimRate < 0)
         {
-            if (nFPSLimit == -1)
-                nFPSLimit = GetDesktopRefreshRate();
-            else if (nFPSLimit == -2)
-                nFPSLimit = GetDesktopRefreshRate() * 2;
+            if (SimRate == -1)
+                SimRate = GetDesktopRefreshRate();
+            else if (SimRate == -2)
+                SimRate = GetDesktopRefreshRate() * 2;
             else
-                nFPSLimit = 60;
+                SimRate = 60;
         }
 
-        static float FrameTime = 1.0f / nFPSLimit;
-        static double dFrameTime = 1.0 / nFPSLimit;
-        //static float fnFPSLimit = (float)nFPSLimit;
-        static double dnFPSLimit = (double)nFPSLimit;
+        // limit rate to avoid issues...
+        if (SimRate > 360)
+            SimRate = 360;
+        if (SimRate < 60)
+            SimRate = 60;
+
+        static float FrameTime = 1.0f / SimRate;
+        static double dFrameTime = 1.0 / SimRate;
+        //static float fSimRate = (float)SimRate;
+        static double dSimRate = (double)SimRate;
 
         // Frame times
         // PrepareRealTimestep() NTSC video mode framerate, .text
@@ -912,7 +918,7 @@ void Init4()
         // Sim::QueueEvents frametime .rdata (this affects gameplay smoothness noticeably)
         float* flt_C23F94 = *hook::pattern("0F 57 C0 F3 0F 10 4C 24 30 0F 2F C1 73 2B").count(1).get(0).get<float*>(0x28); //0x7B89BC anchor, 0x7B89E4 location dereference
 
-        injector::WriteMemory(dword_6ADFEB, &dnFPSLimit, true);
+        injector::WriteMemory(dword_6ADFEB, &dSimRate, true);
         injector::WriteMemory(dbl_BE4208, dFrameTime, true);
         injector::WriteMemory(flt_C05E7C, FrameTime, true);
         injector::WriteMemory(flt_C0CEB4, FrameTime * 10.0f, true);


### PR DESCRIPTION
Better description of what FPSLimit actually did in MW and above.

It didn't limit FPS of the game, but the Sim engine. The renderer is independent of this rate.

Higher this rate, more responsive and faster everything is in the gameplay.

A good thing to do would be to probably find a way to unlock this rate to run as fast as possible.