### PR TITLE
[NFSMW+] disable SimRate limiter

### DIFF
--- a/data/NFSCarbon.WidescreenFix/scripts/NFSCarbon.WidescreenFix.ini
+++ b/data/NFSCarbon.WidescreenFix/scripts/NFSCarbon.WidescreenFix.ini
@@ -18,5 +18,5 @@ CrashFix = 1                             // Solves an issue that caused the game
 ImproveGamepadSupport = 0                // Replaces keyboard icons with gamepad icons and assigns front-end actions. Requires an XInput gamepad. (1 = Xbox Icons | 2 = PlayStation Icons | 3 = None)
 ExpandControllerOptions = 0              // Lists all 29 options in the controller config menu. Will only work with new profiles, existing profiles will crash.
 LeftStickDeadzone = 10.0                 // Controls the deadzone of the left analog stick.
-SimRate = -1                             // Control the refresh rate of the gameplay engine. Affects overall smoothness. Best to match with monitor refresh. (-1 = Default | 0 = Disable patches | -1 = Primary monitor refresh rate | -2 = 2x primary monitor refresh | 60 = Minimum | 360 = Maximum)
+SimRate = -1                             // Control the refresh rate of the gameplay engine. Affects overall smoothness. Best to match with monitor refresh or your target FPS. (-1 = Default | 0 = Disable patches | -1 = Primary monitor refresh rate | -2 = 2x primary monitor refresh)
 DisableMotionBlur = 0                    // Allows users to disable motion blur without changing registry settings and without losing other effects (such as screen flashes or light trails).

--- a/data/NFSMostWanted.WidescreenFix/scripts/NFSMostWanted.WidescreenFix.ini
+++ b/data/NFSMostWanted.WidescreenFix/scripts/NFSMostWanted.WidescreenFix.ini
@@ -20,5 +20,5 @@ WriteSettingsToFile = 0                  // All registry settings will be saved 
 ImproveGamepadSupport = 0                // Replaces keyboard icons with gamepad icons and assigns front-end actions. Requires an XInput gamepad. (1 = Xbox Icons | 2 = PlayStation Icons | 3 = None)
 LeftStickDeadzone = 10.0                 // Controls the deadzone of the left analog stick.
 ForceHighSpecAudio = 1                   // Enables 44100Hz sample rate audio regardless of registry settings.
-SimRate = -1                             // Control the refresh rate of the gameplay engine. Affects overall smoothness. Best to match with monitor refresh. (-1 = Default | 0 = Disable patches | -1 = Primary monitor refresh rate | -2 = 2x primary monitor refresh | 60 = Minimum | 360 = Maximum)
+SimRate = -1                             // Control the refresh rate of the gameplay engine. Affects overall smoothness. Best to match with monitor refresh or your target FPS. (-1 = Default | 0 = Disable patches | -1 = Primary monitor refresh rate | -2 = 2x primary monitor refresh)
 DisableMotionBlur = 0                    // Allows users to disable motion blur without changing registry settings.

--- a/data/NFSProStreet.GenericFix/scripts/NFSProStreet.GenericFix.ini
+++ b/data/NFSProStreet.GenericFix/scripts/NFSProStreet.GenericFix.ini
@@ -21,5 +21,5 @@ LeftStickDeadzone = 10.0                 // Controls the deadzone of the left an
 BrakeLightFix = 1                        // Solves an issue that caused brake lights to only work when ABS was active.
 GammaFix = 1                             // Solves an issue that caused the wrong brightness value to be used on launch.
 ShadowRes = 2048                         // Controls the resolution of dynamic shadows. (2048 = Default) 
-SimRate = -1                             // Control the refresh rate of the gameplay engine. Affects overall smoothness. Best to match with monitor refresh. (-1 = Default | 0 = Disable patches | -1 = Primary monitor refresh rate | -2 = 2x primary monitor refresh | 60 = Minimum | 360 = Maximum)
+SimRate = -1                             // Control the refresh rate of the gameplay engine. Affects overall smoothness. Best to match with monitor refresh or your target FPS. (-1 = Default | 0 = Disable patches | -1 = Primary monitor refresh rate | -2 = 2x primary monitor refresh)
 DisableMotionBlur = 0                    // Disables motion blur without affecting the World FX setting.

--- a/data/NFSUndercover.GenericFix/scripts/NFSUndercover.GenericFix.ini
+++ b/data/NFSUndercover.GenericFix/scripts/NFSUndercover.GenericFix.ini
@@ -22,5 +22,5 @@ CSMScaleFar = 300.0                      // Far cascade (300.0 = Default | 170.0
 ImproveSceneryLOD = 0                    // Increases visible scenery on screen. Increases visible scenery in the closest map section, but may cause flickering for the farther ones.
 DisablePreculler = 0                     // Disables the preculler. (precalculated culling)
 BruteforceCulling = 0                    // Forces the game to use bruteforced culling type instead of TreeCull. This can decrease culled scenery (especially out of bounds), but may increase flicker.
-SimRate = -1                             // Control the refresh rate of the gameplay engine. Affects overall smoothness. Best to match with monitor refresh. (-1 = Default | 0 = Disable patches | -1 = Primary monitor refresh rate | -2 = 2x primary monitor refresh | 60 = Minimum | 360 = Maximum)
+SimRate = -1                             // Control the refresh rate of the gameplay engine. Affects overall smoothness. Best to match with monitor refresh or your target FPS. (-1 = Default | 0 = Disable patches | -1 = Primary monitor refresh rate | -2 = 2x primary monitor refresh)
 DisableMotionBlur = 0                    // Disables motion blur without affecting the World FX setting.

--- a/source/NFSCarbon.WidescreenFix/dllmain.cpp
+++ b/source/NFSCarbon.WidescreenFix/dllmain.cpp
@@ -669,11 +669,12 @@ void Init()
                 SimRate = 60;
         }
 
+        // this shouldn't be necessary - if the game frametime/rate is matched with the sim frametime/rate, then everything is fine.
         // limit rate to avoid issues...
-        if (SimRate > 360)
-            SimRate = 360;
-        if (SimRate < 60)
-            SimRate = 60;
+        //if (SimRate > 360)
+        //    SimRate = 360;
+        //if (SimRate < 60)
+        //    SimRate = 60;
 
         static float FrameTime = 1.0f / SimRate;
         static float fSimRate = (float)SimRate;

--- a/source/NFSMostWanted.WidescreenFix/dllmain.cpp
+++ b/source/NFSMostWanted.WidescreenFix/dllmain.cpp
@@ -874,11 +874,12 @@ void Init()
                 SimRate = 60;
         }
 
+        // this shouldn't be necessary - if the game frametime/rate is matched with the sim frametime/rate, then everything is fine.
         // limit rate to avoid issues...
-        if (SimRate > 360)
-            SimRate = 360;
-        if (SimRate < 60)
-            SimRate = 60;
+        //if (SimRate > 360)
+        //    SimRate = 360;
+        //if (SimRate < 60)
+        //    SimRate = 60;
 
         static float FrameTime = 1.0f / SimRate;
         //static float fnFPSLimit = (float)SimRate;

--- a/source/NFSProStreet.GenericFix/dllmain.cpp
+++ b/source/NFSProStreet.GenericFix/dllmain.cpp
@@ -614,11 +614,12 @@ void Init()
                 SimRate = 60;
         }
 
+        // this shouldn't be necessary - if the game frametime/rate is matched with the sim frametime/rate, then everything is fine.
         // limit rate to avoid issues...
-        if (SimRate > 360)
-            SimRate = 360;
-        if (SimRate < 60)
-            SimRate = 60;
+        //if (SimRate > 360)
+        //    SimRate = 360;
+        //if (SimRate < 60)
+        //    SimRate = 60;
 
         static float FrameTime = 1.0f / SimRate;
         static double dFrameTime = 1.0 / SimRate;

--- a/source/NFSUndercover.GenericFix/dllmain.cpp
+++ b/source/NFSUndercover.GenericFix/dllmain.cpp
@@ -887,11 +887,12 @@ void Init4()
                 SimRate = 60;
         }
 
+        // this shouldn't be necessary - if the game frametime/rate is matched with the sim frametime/rate, then everything is fine.
         // limit rate to avoid issues...
-        if (SimRate > 360)
-            SimRate = 360;
-        if (SimRate < 60)
-            SimRate = 60;
+        //if (SimRate > 360)
+        //    SimRate = 360;
+        //if (SimRate < 60)
+        //    SimRate = 60;
 
         static float FrameTime = 1.0f / SimRate;
         static double dFrameTime = 1.0 / SimRate;


### PR DESCRIPTION
Further testing shows that it wasn't necessary.

When you match FPS for both the game loop and the Sim engine, everything runs fine.

For example - you target 400FPS, the game renders at about 400FPS, the Sim (the actual car simulation) runs fine at 400Hz and the game runs at mostly full speed (depending on the renderer)

If you target 75FPS and the game renders at 75FPS, but you set the Sim to run at 1000Hz, then issues start to arise. The rest of the game is too slow to catch up with the actual gameplay (cameras not reacting to car movements fast enough).

If you target 1000FPS, but the game renders at 75FPS, then it's going to run super slow.

The console versions target 30FPS but has the gameplay loop at 60FPS (because of NTSC refresh rate). Some things run slightly slower (FE animations), but it isn't very noticeable. This is why NFSU2 targets 120Hz, 60FPS for PC, seemingly the only proper PC port. This you can set up by using -2 as the value (or use a custom one yourself instead if you're targeting higher).

In conclusion - everything runs fine as long as it's somewhat closely synchronized. It doesn't have to be perfect, but the renderer has to at least be at half the gameplay rate to run in normal speeds. Sim and gameplay loops need to stay in sync, so therefore this value will stay tied together with the gameplay rate.

As for unlimited FPS - this is also certainly possible, however, we need to then measure the current frametime/framerate and adjust this value accordingly, so everything stays in sync.