### PR TITLE
[NFS] nos trail length fix + adjuster

### DIFF
--- a/data/NFSCarbon.WidescreenFix/scripts/NFSCarbon.WidescreenFix.ini
+++ b/data/NFSCarbon.WidescreenFix/scripts/NFSCarbon.WidescreenFix.ini
@@ -20,3 +20,9 @@ ExpandControllerOptions = 0              // Lists all 29 options in the controll
 LeftStickDeadzone = 10.0                 // Controls the deadzone of the left analog stick.
 SimRate = -1                             // Control the refresh rate of the gameplay engine. Affects overall smoothness. Best to match with monitor refresh or your target FPS. (-1 = Default | 0 = Disable patches | -1 = Primary monitor refresh rate | -2 = 2x primary monitor refresh)
 DisableMotionBlur = 0                    // Allows users to disable motion blur without changing registry settings and without losing other effects (such as screen flashes or light trails).
+
+[NOSTrail]
+FixNOSTrailLength = 1                    // Attempt to fix the NOS trail length for higher FPS.
+CustomNOSTrailLength = 1.0               // Adjust the total distance of the NOS trail. You may need to adjust this if you're playing at very high FPS (240+). Higher the SimRate vs render FPS difference, longer the trail, and the longer the trail, less aligned it becomes with the car.
+FixNOSTrailPosition = 0                  // If FixNOSTrailLength is enabled, this will attempt to fix the NOS trail position from clipping with the car by scaling its position away from the car.
+NOSTrailPositionScalar = 0.3             // If FixNOSTrailPosition is enabled, this will adjust the trail's position away from the car's tail lights.

--- a/data/NFSMostWanted.WidescreenFix/scripts/NFSMostWanted.WidescreenFix.ini
+++ b/data/NFSMostWanted.WidescreenFix/scripts/NFSMostWanted.WidescreenFix.ini
@@ -22,3 +22,9 @@ LeftStickDeadzone = 10.0                 // Controls the deadzone of the left an
 ForceHighSpecAudio = 1                   // Enables 44100Hz sample rate audio regardless of registry settings.
 SimRate = -1                             // Control the refresh rate of the gameplay engine. Affects overall smoothness. Best to match with monitor refresh or your target FPS. (-1 = Default | 0 = Disable patches | -1 = Primary monitor refresh rate | -2 = 2x primary monitor refresh)
 DisableMotionBlur = 0                    // Allows users to disable motion blur without changing registry settings.
+
+[NOSTrail]
+FixNOSTrailLength = 1                    // Attempt to fix the NOS trail length for higher FPS.
+CustomNOSTrailLength = 1.0               // Adjust the total distance of the NOS trail. You may need to adjust this if you're playing at very high FPS (240+). Higher the SimRate vs render FPS difference, longer the trail, and the longer the trail, less aligned it becomes with the car.
+FixNOSTrailPosition = 0                  // If FixNOSTrailLength is enabled, this will attempt to fix the NOS trail position from clipping with the car by scaling its position away from the car.
+NOSTrailPositionScalar = 0.3             // If FixNOSTrailPosition is enabled, this will adjust the trail's position away from the car's tail lights.

--- a/data/NFSUnderground2.WidescreenFix/scripts/NFSUnderground2.WidescreenFix.ini
+++ b/data/NFSUnderground2.WidescreenFix/scripts/NFSUnderground2.WidescreenFix.ini
@@ -18,3 +18,7 @@ LeftStickDeadzone = 10.0                 // Controls the deadzone of the left an
 FPSLimit = -1                            // Allows users to control the framerate limit. (-1 = Default | 0 = Disable patches | -1 = Primary monitor refresh rate | -2 = 2x primary monitor refresh)
 HighFPSCutscenes = 1                     // Increases the framerate limit for cutscenes to the nearest multiple of 30 (maximum is currently 60 due to bugs)
 SingleCoreAffinity = 1                   // Limits game to one CPU core to prevent crashing.
+
+[NOSTrail]
+FixNOSTrailLength = 1                    // Attempt to fix the NOS trail length for higher FPS.
+CustomNOSTrailLength = 1.0               // Adjust the total distance of the NOS trail. You may need to adjust this if you're playing at very high FPS (240+). Higher the FPSLimit vs render FPS difference, longer the trail.

--- a/source/NFSMostWanted.WidescreenFix/dllmain.cpp
+++ b/source/NFSMostWanted.WidescreenFix/dllmain.cpp
@@ -13,6 +13,30 @@ struct Screen
     float fShadowRatio;
 } Screen;
 
+struct bVector3
+{
+    float x;
+    float y;
+    float z;
+    float pad;
+};
+
+struct bVector4
+{
+    float x;
+    float y;
+    float z;
+    float w;
+};
+
+struct bMatrix4
+{
+    bVector4 v0;
+    bVector4 v1;
+    bVector4 v2;
+    bVector4 v3;
+};
+
 bool bIsResizing = false;
 bool bFixHUD = true;
 bool bFixFOV = true;
@@ -120,6 +144,59 @@ LRESULT WINAPI WSFixWndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
     return GameWndProc(hWnd, msg, wParam, lParam);
 }
 
+#pragma runtime_checks( "", off )
+float NOSTrailScalar = 2.0f;
+float NOSTrailPositionScalar = 0.3f;
+bMatrix4 carbody_nos;
+
+void(__thiscall* CarRenderInfo_RenderFlaresOnCar)(void* CarRenderInfo, void* eView, bVector3* vec, bMatrix4* matrix, int unk1, int unk2, int unk3) = (void(__thiscall*)(void*, void*, bVector3*, bMatrix4*, int, int, int))0x00742950;
+void __stdcall CarRenderInfo_RenderFlaresOnCar_Hook(void* eView, bVector3 *position, bMatrix4 *body_matrix, int unk1, int unk2, int unk3)
+{
+    uint32_t thethis = 0;
+    _asm mov thethis, ecx
+    memcpy(&carbody_nos, body_matrix, sizeof(bMatrix4));
+
+    float pos_scale = (NOSTrailScalar * NOSTrailPositionScalar);
+    if (pos_scale < 1.0f)
+        pos_scale = 1.0f;
+
+    carbody_nos.v0.x *= pos_scale;
+    carbody_nos.v0.y *= pos_scale;
+    carbody_nos.v0.z *= pos_scale;
+
+    carbody_nos.v2.x *= pos_scale;
+    carbody_nos.v2.y *= pos_scale;
+
+    return CarRenderInfo_RenderFlaresOnCar((void*)thethis, eView, position, &carbody_nos, unk1, unk2, unk3);
+}
+
+bVector3* WorldPos1;
+bVector3* WorldPos2;
+bVector3* NOSFlarePos;
+
+uint32_t* NOSTrailCave2Exit = (uint32_t*)0x745040;
+void __declspec(naked) NOSTrailCave2()
+{
+    _asm
+    {
+        mov WorldPos1, edx
+        mov WorldPos2, esi
+        lea edx, [esp+0x30]
+        mov NOSFlarePos, edx
+    }
+
+    (*NOSFlarePos).x = ((*WorldPos1).x - (*WorldPos2).x) * NOSTrailScalar;
+    (*NOSFlarePos).y = ((*WorldPos1).y - (*WorldPos2).y) * NOSTrailScalar;
+    (*NOSFlarePos).z = ((*WorldPos1).z - (*WorldPos2).z) * NOSTrailScalar;
+
+    _asm
+    {
+        xor eax, eax
+        jmp NOSTrailCave2Exit
+    }
+}
+#pragma runtime_checks( "", restore )
+
 void Init()
 {
     CIniReader iniReader("");
@@ -147,6 +224,10 @@ void Init()
     if (szCustomUserFilesDirectoryInGameDir.empty() || szCustomUserFilesDirectoryInGameDir == "0")
         szCustomUserFilesDirectoryInGameDir.clear();
     int nWindowedMode = iniReader.ReadInteger("MISC", "WindowedMode", 0);
+    bool bFixNOSTrailLength = iniReader.ReadInteger("NOSTrail", "FixNOSTrailLength", 1) == 1;
+    bool bFixNOSTrailPosition = iniReader.ReadInteger("NOSTrail", "FixNOSTrailPosition", 0) != 0;
+    static float fCustomNOSTrailLength = iniReader.ReadFloat("NOSTrail", "CustomNOSTrailLength", 1.0f);
+    NOSTrailPositionScalar = iniReader.ReadFloat("NOSTrail", "NOSTrailPositionScalar", 0.3f);
 
     if (!Screen.Width || !Screen.Height)
         std::tie(Screen.Width, Screen.Height) = GetDesktopRes();
@@ -905,6 +986,29 @@ void Init()
 
         // Frame rates
         // TODO: if any issues arise, figure out where 60.0 values are used and update the constants...
+    }
+
+    if (bFixNOSTrailLength)
+    {
+        static int TargetRate = 60;
+
+        if (SimRate)
+            TargetRate = SimRate;
+
+        constexpr float NOSTargetFPS = 60.0f; // original FPS we're targeting from. Consoles target 60 but run at 30, hence have longer trails than PC. Targeting 60 is smarter due to less issues with shorter trails. Use SimRate -2 to get the same effect as console versions.
+        NOSTrailScalar = (TargetRate / NOSTargetFPS) * fCustomNOSTrailLength;
+
+        pattern = hook::pattern("EB 06 8D 9B 00 00 00 00 40 89 44 24 18"); // 0x00745038
+        injector::MakeJMP(pattern.get_first(0), NOSTrailCave2, true);
+        NOSTrailCave2Exit = (uint32_t*)pattern.get_first(8);
+
+        if (bFixNOSTrailPosition)
+        {
+            pattern = hook::pattern("D9 44 24 30 6A 02 D8 4C 24 10 6A 00 8B CB C1 E1 06"); // 0x00745088
+            injector::MakeCALL(pattern.get_first(0x60), CarRenderInfo_RenderFlaresOnCar_Hook, true);
+            pattern = hook::pattern("55 8B EC 83 E4 F0 83 EC 74 53 56 57 8B F9 89 7C 24 3C"); // 0x00742950
+            CarRenderInfo_RenderFlaresOnCar = (void(__thiscall*)(void*, void*, bVector3*, bMatrix4*, int, int, int))pattern.get_first(0);
+        }
     }
 
     if (bWriteSettingsToFile)

--- a/source/NFSUnderground2.WidescreenFix/dllmain.cpp
+++ b/source/NFSUnderground2.WidescreenFix/dllmain.cpp
@@ -82,7 +82,7 @@ uint32_t* NOSTrailCaveExitTrue = (uint32_t*)0x0061AD91;
 uint32_t* NOSTrailCaveExitFalse = (uint32_t*)0x61AE8E;
 void __declspec(naked) NOSTrailCave()
 {
-    if ((*fc_12989_8A44EC + NOSTrailFrameDelay) < *eFrameCounter_870818)
+    if ((*fc_12989_8A44EC + NOSTrailFrameDelay) <= *eFrameCounter_870818)
         _asm
         {
             mov eax, ds:eFrameCounter_870818

--- a/source/NFSUnderground2.WidescreenFix/dllmain.cpp
+++ b/source/NFSUnderground2.WidescreenFix/dllmain.cpp
@@ -75,6 +75,24 @@ HANDLE WINAPI CustomCreateThread(LPSECURITY_ATTRIBUTES lpThreadAttributes, SIZE_
     return hThread;
 }
 
+static uint32_t NOSTrailFrameDelay = 1;
+uint32_t* eFrameCounter_870818 = (uint32_t*)0x00870818;
+uint32_t* fc_12989_8A44EC = (uint32_t*)0x008A44EC;
+uint32_t* NOSTrailCaveExitTrue = (uint32_t*)0x0061AD91;
+uint32_t* NOSTrailCaveExitFalse = (uint32_t*)0x61AE8E;
+void __declspec(naked) NOSTrailCave()
+{
+    if ((*fc_12989_8A44EC + NOSTrailFrameDelay) < *eFrameCounter_870818)
+        _asm
+        {
+            mov eax, ds:eFrameCounter_870818
+            mov eax, [eax]
+            jmp NOSTrailCaveExitTrue
+        }
+    else
+        _asm jmp NOSTrailCaveExitFalse
+}
+
 void Init()
 {
     CIniReader iniReader("");
@@ -99,6 +117,8 @@ void Init()
     if (szCustomUserFilesDirectoryInGameDir.empty() || szCustomUserFilesDirectoryInGameDir == "0")
         szCustomUserFilesDirectoryInGameDir.clear();
     int nWindowedMode = iniReader.ReadInteger("MISC", "WindowedMode", 0);
+    bool bFixNOSTrailLength = iniReader.ReadInteger("NOSTrail", "FixNOSTrailLength", 1) == 1;
+    static float fCustomNOSTrailLength = iniReader.ReadFloat("NOSTrail", "CustomNOSTrailLength", 1.0f);
 
     if (!Screen.Width || !Screen.Height)
         std::tie(Screen.Width, Screen.Height) = GetDesktopRes();
@@ -856,6 +876,25 @@ void Init()
             WindowedModeWrapper::bBorderlessWindowed = false;
         if (nWindowedMode > 2) // TODO: implement dynamic resizing (like in MW)
             WindowedModeWrapper::bEnableWindowResize = true;
+    }
+
+    if (bFixNOSTrailLength)
+    {
+        static int TargetRate = 60;
+
+        if (nFPSLimit)
+            TargetRate = nFPSLimit;
+
+        static uint32_t NOSTargetFPS = 60; // original FPS we're targeting from. Consoles target 60 but run at 30, hence have longer trails than PC. Targeting 60 is smarter due to less issues with shorter trails. Use SimRate -2 to get the same effect as console versions.
+        static float fNOSTrailFrameDelay = ((float)TargetRate / (float)NOSTargetFPS) * fCustomNOSTrailLength;
+        NOSTrailFrameDelay = (uint32_t)round(fNOSTrailFrameDelay);
+
+        pattern = hook::pattern("81 C1 15 02 00 00 C1 E1 04"); // 0x0061AE69
+        eFrameCounter_870818 = *pattern.count(1).get(0).get<uint32_t*>(-0xE8);
+        fc_12989_8A44EC = *pattern.count(1).get(0).get<uint32_t*>(-0xE2);
+        NOSTrailCaveExitTrue = (uint32_t*)pattern.get_first(-0xD8);
+        NOSTrailCaveExitFalse = (uint32_t*)pattern.get_first(0x25);
+        injector::MakeJMP(pattern.get_first(-0xE9), NOSTrailCave, true);
     }
 }
 


### PR DESCRIPTION
This will scale the length of the NOS trails with the desired framerate defined with SimRate to make it behave like the stock game.

Everything should be described in the ini entries. The trail becomes longer with the difference between SimRate and render FPS. For this reason, the console entries have longer trail distances.

The longer the trail distance is, less aligned it is with the car and more it clips through, hence why I added the option FixNOSTrailPosition.

This potentially could be fixed with some math in CarRenderInfo_RenderFlaresOnCar_Hook, but I'm honestly too stupid to figure that one out.

One thing I have to note - the hook in 0x00745038 is extremely clean. So clean, in fact, that it doesn't affect game code whatsoever. For some reason there is just one instruction below the short jmp ```lea     ebx, [ebx+0]``` which is completely unused. This may have been done by the NoCD crackers. (EDIT: this doesn't seem to be true because the same is in Carbon, so it was the compiler that did it weirdly enough...)

TODO:
- UG2 and Carbon ports
- UG2 and MW light trail lengths (similar problem, might bundle it together with this PR)