### PR TITLE
Do less math in common FOV calculations

### DIFF
--- a/includes/stdafx.cpp
+++ b/includes/stdafx.cpp
@@ -2,12 +2,12 @@
 
 float GetFOV(float f, float ar)
 {
-    return atan2(tan(atan2(tan(f * 0.5f) / (4.0f / 3.0f), 1.0f)) * (ar), 1.0f);
+    return atan(3.0f / 4.0f * ar * tan(f * 0.5f));
 }
 
 float GetFOV2(float f, float ar)
 {
-    return f * (2.0f * ((180.0f / (float)M_PI) * (atan(tan(((float)M_PI / 180.0f) * ((2.0f * ((180.0f / (float)M_PI) * (atan(tan(((float)M_PI / 180.0f) * (90.0f * 0.5f)) / (4.0f / 3.0f))))) * 0.5f)) * (ar)))) * (1.0f / 90.0f));
+    return 4.0f * f * atan(ar * (3.0f / 4.0f)) / (float)M_PI;
 }
 
 float AdjustFOV(float f, float ar)


### PR DESCRIPTION
I'm not sure if there was a reason for these formulas to be written the way they were (like accuracy or weird edge cases or something), but if there were none, this should look a bit cleaner and use a bit fewer math function calls.