### PR TITLE
[NFSPS/C] disable runtime checks & remove LazyHook

### DIFF
--- a/source/NFSCarbon.WidescreenFix/dllmain.cpp
+++ b/source/NFSCarbon.WidescreenFix/dllmain.cpp
@@ -91,6 +91,7 @@ void __declspec(naked) NOSTrailCave2()
 
 uint32_t* dword_AB0ABC = (uint32_t*)0x00AB0ABC;
 void(__thiscall* sub_723380)(void* that, void* texture) = (void(__thiscall*)(void*, void*))0x723380;
+#pragma runtime_checks( "", disable )
 void __stdcall sub_723380_hook(void* texture)
 {
     void* that;
@@ -100,6 +101,7 @@ void __stdcall sub_723380_hook(void* texture)
     LPDIRECT3DDEVICE9 gDevice = *(LPDIRECT3DDEVICE9*)dword_AB0ABC;
     gDevice->SetRenderState(D3DRS_DESTBLEND, D3DBLEND_ONE);
 }
+#pragma runtime_checks( "", restore )
 
 uint32_t* LightingFixUpdateMirrorCave_Exit = (uint32_t*)0x00748C5D;
 uint32_t* sub_713AA0 = (uint32_t*)0x713AA0;

--- a/source/NFSProStreet.GenericFix/dllmain.cpp
+++ b/source/NFSProStreet.GenericFix/dllmain.cpp
@@ -72,6 +72,7 @@ uint32_t* dword_AC6ED4 = (uint32_t*)0x00AC6ED4;
 static bool bInSparkRender = false;
 void(__thiscall* sub_706550)(void* that, void* texture) = (void(__thiscall*)(void*, void*))0x706550;
 void(__thiscall* XSpriteManager_DrawBatch)(void* that, void* view) = (void(__thiscall*)(void*, void*))0x004B61C0;
+#pragma runtime_checks( "", disable )
 void __stdcall XSpriteManager_DrawBatch_Hook(void* view)
 {
     void* that;
@@ -94,10 +95,11 @@ void __stdcall sub_706550_hook(void* texture)
         gDevice->SetRenderState(D3DRS_DESTBLEND, D3DBLEND_ONE);
     }
 }
+#pragma runtime_checks( "", restore )
 
 void Init()
 {
-    FreeConsole();
+    //FreeConsole();
 
     //Stop settings reset after crash
     auto pattern = hook::pattern("C7 44 24 ? ? ? ? ? FF 15 ? ? ? ? 8D 54 24 0C 52");
@@ -463,7 +465,8 @@ void Init()
         injector::MakeNOP(dword_70E39B, 6, true);
         injector::MakeCALL(dword_70E39B, WindowedModeWrapper::AdjustWindowRect_Hook, true);
         // enable windowed mode variable
-        *WindowedMode_AC6EFC = 1;
+        //*WindowedMode_AC6EFC = 1;
+        injector::WriteMemory<uint32_t>(0xAC6EFC, 1, true);
 
         if (nWindowedMode > 1)
             WindowedModeWrapper::bBorderlessWindowed = false;

--- a/source/NFSProStreet.GenericFix/dllmain.cpp
+++ b/source/NFSProStreet.GenericFix/dllmain.cpp
@@ -706,41 +706,35 @@ void Init()
 
     if (bWriteSettingsToFile)
     {
-      struct LazyHook
-      {
-        static void hook()
-        {
-          auto GetFolderPathpattern = hook::pattern("50 6A 00 6A 00 68 ? 80 00 00 6A 00");
-          while (!injector::GetBranchDestination(GetFolderPathpattern.get(0).get<uintptr_t>(14), true).as_int())
-            std::this_thread::sleep_for(std::chrono::seconds(1));
+        auto GetFolderPathpattern = hook::pattern("50 6A 00 6A 00 68 ? 80 00 00 6A 00");
 
-          if (!szCustomUserFilesDirectoryInGameDir.empty())
-          {
+        if (!szCustomUserFilesDirectoryInGameDir.empty())
+        {
             szCustomUserFilesDirectoryInGameDir = GetExeModulePath<std::string>() + szCustomUserFilesDirectoryInGameDir;
 
             auto SHGetFolderPathAHook = [](HWND /*hwnd*/, int /*csidl*/, HANDLE /*hToken*/, DWORD /*dwFlags*/, LPSTR pszPath) -> HRESULT
             {
-              CreateDirectoryA(szCustomUserFilesDirectoryInGameDir.c_str(), NULL);
-              strcpy(pszPath, szCustomUserFilesDirectoryInGameDir.c_str());
-              return S_OK;
+                CreateDirectoryA(szCustomUserFilesDirectoryInGameDir.c_str(), NULL);
+                strcpy(pszPath, szCustomUserFilesDirectoryInGameDir.c_str());
+                return S_OK;
             };
 
             for (size_t i = 0; i < GetFolderPathpattern.size(); i++)
             {
-              uint32_t* dword_6CBF17 = GetFolderPathpattern.get(i).get<uint32_t>(12);
-              if (*(BYTE*)dword_6CBF17 != 0xFF)
-                dword_6CBF17 = GetFolderPathpattern.get(i).get<uint32_t>(14);
+                uint32_t* dword_6CBF17 = GetFolderPathpattern.get(i).get<uint32_t>(12);
+                if (*(BYTE*)dword_6CBF17 != 0xFF)
+                    dword_6CBF17 = GetFolderPathpattern.get(i).get<uint32_t>(14);
 
-              injector::MakeCALL((uint32_t)dword_6CBF17, static_cast<HRESULT(WINAPI*)(HWND, int, HANDLE, DWORD, LPSTR)>(SHGetFolderPathAHook), true);
-              injector::MakeNOP((uint32_t)dword_6CBF17 + 5, 1, true);
+                injector::MakeCALL((uint32_t)dword_6CBF17, static_cast<HRESULT(WINAPI*)(HWND, int, HANDLE, DWORD, LPSTR)>(SHGetFolderPathAHook), true);
+                injector::MakeNOP((uint32_t)dword_6CBF17 + 5, 1, true);
             }
-          }
+        }
 
-          auto[DesktopResW, DesktopResH] = GetDesktopRes();
-          char szSettingsSavePath[MAX_PATH];
-          uintptr_t GetFolderPathCallDest = injector::GetBranchDestination(GetFolderPathpattern.get(0).get<uintptr_t>(14), true).as_int();
-          if (GetFolderPathCallDest)
-          {
+        auto [DesktopResW, DesktopResH] = GetDesktopRes();
+        char szSettingsSavePath[MAX_PATH];
+        uintptr_t GetFolderPathCallDest = injector::GetBranchDestination(GetFolderPathpattern.get(0).get<uintptr_t>(14), true).as_int();
+        if (GetFolderPathCallDest)
+        {
             injector::stdcall<HRESULT(HWND, int, HANDLE, DWORD, LPSTR)>::call(GetFolderPathCallDest, NULL, 0x8005, NULL, NULL, szSettingsSavePath);
             strcat(szSettingsSavePath, "\\NFS ProStreet");
             strcat(szSettingsSavePath, "\\Settings.ini");
@@ -780,11 +774,7 @@ void Init()
             RegistryWrapper::AddDefault("g_Width", std::to_string(DesktopResW));
             RegistryWrapper::AddDefault("g_Height", std::to_string(DesktopResH));
             RegistryWrapper::AddDefault("g_Refresh", "60");
-          }
         }
-      };
-
-      std::thread(LazyHook::hook).detach();
     }
 
     if (bDisableMotionBlur)


### PR DESCRIPTION
- Runtime checks were causing crashing in Debug build configurations
- LazyHook in ProStreet was causing issues with settings file loading on slower machines, disabling it fixes it. Vitality works without it now.