### PR TITLE
make windowed options backwards compatible

### DIFF
--- a/data/NFSCarbon.WidescreenFix/scripts/NFSCarbon.WidescreenFix.ini
+++ b/data/NFSCarbon.WidescreenFix/scripts/NFSCarbon.WidescreenFix.ini
@@ -9,7 +9,7 @@ FMVWidescreenMode = 1                    // FMVs will appear in fullscreen for 1
 
 [MISC]
 SkipIntro = 0                            // Skips FMVs that play when you launch the game.
-WindowedMode = 0                         // Enables windowed mode. (1 = Borderless scaled | 2 = Borderless stretch | 3 = Borderless no scale | 4 = Border | 5 = Border with resizing)
+WindowedMode = 0                         // Enables windowed mode. (1 = Borderless no scale | 2 = Border | 3 = Border with resizing | 4 = Borderless scaled | 5 = Borderless stretch)
 LightingFix = 1                          // Adjusts lighting to match the Xbox 360 version.
 CarShadowFix = 1                         // Reduces shadow opacity to match the Xbox 360 version.
 CustomUserFilesDirectoryInGameDir = 0    // User files will be stored in a specified directory (for example: "save"). Use '0' to disable.

--- a/data/NFSMostWanted.WidescreenFix/scripts/NFSMostWanted.WidescreenFix.ini
+++ b/data/NFSMostWanted.WidescreenFix/scripts/NFSMostWanted.WidescreenFix.ini
@@ -9,7 +9,7 @@ FMVWidescreenMode = 1                    // FMVs will appear in fullscreen for 1
 
 [MISC]
 SkipIntro = 0                            // Skips FMVs that play when you launch the game.
-WindowedMode = 0                         // Enables windowed mode. (1 = Borderless scaled | 2 = Borderless stretch | 3 = Borderless no scale | 4 = Border | 5 = Border with dynamic resizing)
+WindowedMode = 0                         // Enables windowed mode. (1 = Borderless no scale | 2 = Border | 3 = Border with dynamic resizing | 4 = Borderless scaled | 5 = Borderless stretch)
 ShadowsRes = 1024                        // Controls the resolution of dynamic shadows and enables them for Intel GPUs. (1024 = Default | 2048 = Xbox 360)
 AutoScaleShadowsRes = 0                  // Adjusts the specified ShadowsRes based on the user's aspect ratio to maintain quality. This may negatively affect performance.
 ShadowsFix = 1                           // Dynamic shadows will no longer disappear when going into tunnels, under bridges, etc.

--- a/data/NFSProStreet.GenericFix/scripts/NFSProStreet.GenericFix.ini
+++ b/data/NFSProStreet.GenericFix/scripts/NFSProStreet.GenericFix.ini
@@ -14,7 +14,7 @@ ConsoleHUDSize = 0                       // Makes the HUD smaller like the conso
 
 [MISC]
 SkipIntro = 0                            // Skips FMVs that play when you launch the game.
-WindowedMode = 0                         // Enables windowed mode. (1 = Borderless scaled | 2 = Borderless stretch | 3 = Borderless no scale | 4 = Border | 5 = Border with resizing)
+WindowedMode = 0                         // Enables windowed mode. (1 = Borderless no scale | 2 = Border | 3 = Border with resizing | 4 = Borderless scaled | 5 = Borderless stretch)
 CustomUserFilesDirectoryInGameDir = 0    // User files will be stored in a specified directory (for example: "save"). Use '0' to disable.
 WriteSettingsToFile = 0                  // All registry settings will be saved to "settings.ini" in your profile folder. You must input your CD key and langauge in "settings.ini" when this option is enabled.
 ImproveGamepadSupport = 0                // Replaces keyboard icons with gamepad icons and assigns front-end actions. Requires an XInput gamepad. (1 = Xbox Icons | 2 = PlayStation Icons | 3 = None)

--- a/data/NFSUndercover.GenericFix/scripts/NFSUndercover.GenericFix.ini
+++ b/data/NFSUndercover.GenericFix/scripts/NFSUndercover.GenericFix.ini
@@ -6,7 +6,7 @@ Scaling = 0                              // Adjusts FOV scaling to be proportion
 
 [MISC]
 SkipIntro = 0                            // Skips FMVs that play when you launch the game.
-WindowedMode = 0                         // Enables windowed mode. (1 = Borderless scaled | 2 = Borderless stretch | 3 = Borderless no scale | 4 = Border | 5 = Border with resizing)
+WindowedMode = 0                         // Enables windowed mode. (1 = Borderless no scale | 2 = Border | 3 = Border with resizing | 4 = Borderless scaled | 5 = Borderless stretch)
 CustomUserFilesDirectoryInGameDir = 0    // User files will be stored in a specified directory (for example: "save"). Use '0' to disable.
 WriteSettingsToFile = 0                  // All registry settings will be saved to "settings.ini" in your profile folder. You must input your CD key and langauge in "settings.ini" when this option is enabled.
 ImproveGamepadSupport = 0                // Replaces keyboard icons with gamepad icons and assigns front-end actions. Requires an XInput gamepad. (1 = Xbox Icons | 2 = PlayStation Icons | 3 = None)

--- a/data/NFSUnderground.WidescreenFix/scripts/NFSUnderground.WidescreenFix.ini
+++ b/data/NFSUnderground.WidescreenFix/scripts/NFSUnderground.WidescreenFix.ini
@@ -9,7 +9,7 @@ FMVWidescreenMode = 1                    // FMVs will appear in fullscreen for 1
 
 [MISC]
 SkipIntro = 0                            // Skips FMVs that play when you launch the game.
-WindowedMode = 0                         // Enables windowed mode. (1 = Borderless scaled | 2 = Borderless stretch | 3 = Borderless no scale | 4 = Border | 5 = Border with resizing)
+WindowedMode = 0                         // Enables windowed mode. (1 = Borderless no scale | 2 = Border | 3 = Border with resizing | 4 = Borderless scaled | 5 = Borderless stretch)
 HideDebugObjects = 1                     // Hides debug objects. (1 = Removed by code | 2 = Adds borders to the front-end)
 CustomUserFilesDirectoryInGameDir = 0    // User files will be stored in a specified directory (for example: "save"). Use '0' to disable.
 ImproveGamepadSupport = 0                // Replaces keyboard icons with gamepad icons and assigns front-end actions. Requires an XInput gamepad. (1 = Xbox Icons | 2 = PlayStation Icons | 3 = None)

--- a/data/NFSUnderground2.WidescreenFix/scripts/NFSUnderground2.WidescreenFix.ini
+++ b/data/NFSUnderground2.WidescreenFix/scripts/NFSUnderground2.WidescreenFix.ini
@@ -9,7 +9,7 @@ FMVWidescreenMode = 1                    // FMVs will appear in fullscreen for 1
 
 [MISC]
 SkipIntro = 0                            // Skips FMVs that play when you launch the game.
-WindowedMode = 0                         // Enables windowed mode. (1 = Borderless scaled | 2 = Borderless stretch | 3 = Borderless no scale | 4 = Border | 5 = Border with resizing)
+WindowedMode = 0                         // Enables windowed mode. (1 = Borderless no scale | 2 = Border | 3 = Border with resizing | 4 = Borderless scaled | 5 = Borderless stretch)
 DisableCutsceneBorders = 1               // Removes letterboxing that appears during cutscenes.
 CustomUserFilesDirectoryInGameDir = 0    // User files will be stored in a specified directory (for example: "save"). Use '0' to disable.
 WriteSettingsToFile = 0                  // All registry settings will be saved to "settings.ini" in your profile folder. You must input your CD key and langauge in "settings.ini" when this option is enabled.

--- a/includes/stdafx.h
+++ b/includes/stdafx.h
@@ -786,7 +786,7 @@ namespace WindowedModeWrapper
 {
     static bool bBorderlessWindowed = true;
     static bool bEnableWindowResize = false;
-    static bool bScaleWindow = true;
+    static bool bScaleWindow = false;
     static bool bStretchWindow = false;
     static HWND GameHWND = NULL;
 

--- a/source/NFSCarbon.WidescreenFix/dllmain.cpp
+++ b/source/NFSCarbon.WidescreenFix/dllmain.cpp
@@ -545,17 +545,16 @@ void Init()
 
         switch (nWindowedMode)
         {
-        case 5:  // TODO: implement dynamic resizing (like in MW)
-            WindowedModeWrapper::bEnableWindowResize = true;
-        case 4:
-            WindowedModeWrapper::bBorderlessWindowed = false;
-        case 3:
-            WindowedModeWrapper::bStretchWindow = false;
-            WindowedModeWrapper::bScaleWindow = false;
-            break;
-        case 2:
+        case 5:
             WindowedModeWrapper::bStretchWindow = true;
-            WindowedModeWrapper::bScaleWindow = false;
+            break;
+        case 4:
+            WindowedModeWrapper::bScaleWindow = true;
+            break;
+        case 3:  // TODO: implement dynamic resizing (like in MW)
+            WindowedModeWrapper::bEnableWindowResize = true;
+        case 2:
+            WindowedModeWrapper::bBorderlessWindowed = false;
             break;
         default:
             break;

--- a/source/NFSMostWanted.WidescreenFix/dllmain.cpp
+++ b/source/NFSMostWanted.WidescreenFix/dllmain.cpp
@@ -884,15 +884,14 @@ void Init()
         switch (nWindowedMode)
         {
         case 5:
-        case 4:
-            WindowedModeWrapper::bBorderlessWindowed = false;
-        case 3:
-            WindowedModeWrapper::bStretchWindow = false;
-            WindowedModeWrapper::bScaleWindow = false;
-            break;
-        case 2:
             WindowedModeWrapper::bStretchWindow = true;
-            WindowedModeWrapper::bScaleWindow = false;
+            break;
+        case 4:
+            WindowedModeWrapper::bScaleWindow = true;
+            break;
+        case 3:
+        case 2:
+            WindowedModeWrapper::bBorderlessWindowed = false;
             break;
         default:
             break;

--- a/source/NFSProStreet.GenericFix/dllmain.cpp
+++ b/source/NFSProStreet.GenericFix/dllmain.cpp
@@ -472,18 +472,16 @@ void Init()
 
         switch (nWindowedMode)
         {
-        case 5:  // TODO: implement dynamic resizing (like in MW)
-            WindowedModeWrapper::bEnableWindowResize = true;
-        case 4:
-            WindowedModeWrapper::bBorderlessWindowed = false;
-            break;
-        case 3:
-            WindowedModeWrapper::bStretchWindow = false;
-            WindowedModeWrapper::bScaleWindow = false;
-            break;
-        case 2:
+        case 5:
             WindowedModeWrapper::bStretchWindow = true;
-            WindowedModeWrapper::bScaleWindow = false;
+            break;
+        case 4:
+            WindowedModeWrapper::bScaleWindow = true;
+            break;
+        case 3:  // TODO: implement dynamic resizing (like in MW)
+            WindowedModeWrapper::bEnableWindowResize = true;
+        case 2:
+            WindowedModeWrapper::bBorderlessWindowed = false;
             break;
         default:
             break;

--- a/source/NFSUndercover.GenericFix/dllmain.cpp
+++ b/source/NFSUndercover.GenericFix/dllmain.cpp
@@ -757,17 +757,16 @@ void Init4()
 
         switch (nWindowedMode)
         {
-        case 5:  // TODO: implement dynamic resizing (like in MW)
-            WindowedModeWrapper::bEnableWindowResize = true;
-        case 4:
-            WindowedModeWrapper::bBorderlessWindowed = false;
-        case 3:
-            WindowedModeWrapper::bStretchWindow = false;
-            WindowedModeWrapper::bScaleWindow = false;
-            break;
-        case 2:
+        case 5:
             WindowedModeWrapper::bStretchWindow = true;
-            WindowedModeWrapper::bScaleWindow = false;
+            break;
+        case 4:
+            WindowedModeWrapper::bScaleWindow = true;
+            break;
+        case 3:  // TODO: implement dynamic resizing (like in MW)
+            WindowedModeWrapper::bEnableWindowResize = true;
+        case 2:
+            WindowedModeWrapper::bBorderlessWindowed = false;
             break;
         default:
             break;

--- a/source/NFSUnderground.WidescreenFix/dllmain.cpp
+++ b/source/NFSUnderground.WidescreenFix/dllmain.cpp
@@ -1056,17 +1056,16 @@ void Init()
 
         switch (nWindowedMode)
         {
-        case 5:  // TODO: implement dynamic resizing (like in MW)
-            WindowedModeWrapper::bEnableWindowResize = true;
-        case 4:
-            WindowedModeWrapper::bBorderlessWindowed = false;
-        case 3:
-            WindowedModeWrapper::bStretchWindow = false;
-            WindowedModeWrapper::bScaleWindow = false;
-            break;
-        case 2:
+        case 5:
             WindowedModeWrapper::bStretchWindow = true;
-            WindowedModeWrapper::bScaleWindow = false;
+            break;
+        case 4:
+            WindowedModeWrapper::bScaleWindow = true;
+            break;
+        case 3:  // TODO: implement dynamic resizing (like in MW)
+            WindowedModeWrapper::bEnableWindowResize = true;
+        case 2:
+            WindowedModeWrapper::bBorderlessWindowed = false;
             break;
         default:
             break;

--- a/source/NFSUnderground2.WidescreenFix/dllmain.cpp
+++ b/source/NFSUnderground2.WidescreenFix/dllmain.cpp
@@ -874,17 +874,16 @@ void Init()
 
         switch (nWindowedMode)
         {
-        case 5:  // TODO: implement dynamic resizing (like in MW)
-            WindowedModeWrapper::bEnableWindowResize = true;
-        case 4:
-            WindowedModeWrapper::bBorderlessWindowed = false;
-        case 3:
-            WindowedModeWrapper::bStretchWindow = false;
-            WindowedModeWrapper::bScaleWindow = false;
-            break;
-        case 2:
+        case 5:
             WindowedModeWrapper::bStretchWindow = true;
-            WindowedModeWrapper::bScaleWindow = false;
+            break;
+        case 4:
+            WindowedModeWrapper::bScaleWindow = true;
+            break;
+        case 3:  // TODO: implement dynamic resizing (like in MW)
+            WindowedModeWrapper::bEnableWindowResize = true;
+        case 2:
+            WindowedModeWrapper::bBorderlessWindowed = false;
             break;
         default:
             break;


### PR DESCRIPTION
made windowed mode options backwards compatible:

`(1 = Borderless no scale | 2 = Border | 3 = Border with resizing | 4 = Borderless scaled | 5 = Borderless stretch)`