### PR TITLE
[NFSPS] big update

### DIFF
--- a/data/NFSProStreet.GenericFix/scripts/NFSProStreet.GenericFix.ini
+++ b/data/NFSProStreet.GenericFix/scripts/NFSProStreet.GenericFix.ini
@@ -7,6 +7,8 @@ AntiTrackStreamerCrash = 1               // Adds memory checks for the TrackStre
 AntiFEScriptCrash = 1                    // Adds memory checks for FE::Object::SetScript
 DisableAchievements = 1                  // Disables the integrated achievement system. Potentially increases game stability. These are not normally visible in the PC version.
 DisableBoosterPackThanks = 1             // Skips the booster pack / DLC thanks screen on new profiles (v1.1 and newer only)
+DisablePunkBuster = 1                    // Disables PunkBuster anti-cheat to potentially increase game stability.
+DamageMemoryLeakFix = 1                  // Fixes a memory leak in damage memory pools. Increases stability during a long play session, but also slightly increases memory requirements per-race until you exit the hub.
 
 [MAIN]
 FixAspectRatio = 1                       // Corrects the width of the HUD, FOV, and FMVs.
@@ -16,6 +18,7 @@ ConsoleHUDSize = 0                       // Makes the HUD smaller like the conso
 
 [MISC]
 SkipIntro = 0                            // Skips FMVs that play when you launch the game.
+SkipFEBootflow = 0                       // Skips the entire bootflow process and goes straight to main menu. Useful for skipping boot screens in the demo version. WARNING: You cannot load your alias if this is enabled!
 WindowedMode = 0                         // Enables windowed mode. (1 = Borderless Windowed | 2 = Border | 3 = Border with resizing | 4 = Borderless Fullscreen | 5 = Borderless Fullscreen (Stretched))
 CustomUserFilesDirectoryInGameDir = 0    // User files will be stored in a specified directory (for example: "save"). Use '0' to disable.
 WriteSettingsToFile = 0                  // All registry settings will be saved to "settings.ini" in your profile folder. You must input your CD key and langauge in "settings.ini" when this option is enabled.


### PR DESCRIPTION
- Added a fix for a memory leak while car damage is enabled (explanation below)
- Fixed patterns to support the demo versions (which are also DRM free!)
- Added an (attempted) PunkBuster disabler
- Added SkipFEBootflow option (mainly for the demo builds but also works in final)

OK so, the memory leak fix is a pretty big one.

Simply put - someone at Black Box forgot to free the memory pools for car damage (and their vertex buffers, DamagePool and DamageVBPool respectively) during runtime. This causes a memory leak which usually results in a crash after about 4 hours of playback.

(The time until crash varied on your free memory + free memory in the game's address space, which is 32 bits, non large address aware by default)

The fix consists of telling the game to release the two memory pools each time it exits the game (EQuitToFE) and enters FE.

There was a yet another oversight where the car damage skins were created only once, which had to be disabled for the sake of this memory leak patch to work. This causes slightly higher memory usage during game runtime (per each damage skin loaded).

However, a scenario where the user will run out of memory is unlikely, as it happens after about 200 or so loaded races during a single race day, so it should be fine if the user plays the game normally.

I'd love to make a better fix, but this is as far as I can take it without going crazy and actually _decompiling_ the game and/or having access to the sources.