### PR TITLE
[NFSPS] Fixed aspect ratio bug

### DIFF
--- a/source/NFSProStreet.GenericFix/dllmain.cpp
+++ b/source/NFSProStreet.GenericFix/dllmain.cpp
@@ -574,7 +574,7 @@ void Init()
                     int ebp08 = *(int*)(regs.ebp + 0x08);
                     float esp48 = *(float*)(regs.esp + 0x48);
 
-                    if (ebp08 == 1) // jne
+                    if (ebp08 < 0x1D) // jump not less than
                         *(float*)(regs.esp + 0x48) = (esp48 / fScreenAspectRatio);
 
                     _asm


### PR DESCRIPTION
Fixed an issue with the depth buffer not scaling correctly for widescreen aspect ratios. This error effected the in-game motion blur and specific ReShade effects that relied on the depth buffer.