### PR TITLE
[Sonic Heroes] implement better FPS limiter

### DIFF
--- a/data/SonicHeroes.WidescreenFix/scripts/SonicHeroes.WidescreenFix.ini
+++ b/data/SonicHeroes.WidescreenFix/scripts/SonicHeroes.WidescreenFix.ini
@@ -23,6 +23,9 @@ RestoreDemos = 1                         ; Restores attract demos on the title s
 IncreaseObjectDistance = 1               ; Enables object visibility distance adjustment by MinObjDistance and ObjDistanceScale. Reduces object pop-in.
 MinObjDistance = 0                       ; Minimum object distance (Min = 0, Max = 255, Default = 0)
 ObjDistanceScale = 2.0                   ; Object distance scalar. (Min = 0.0, Max = 255.0, Default = 2.0)
+BetterFrameSync = 1                      ; Improved framerate limiter with less frametime jitter. If enabled, maximum framerate will be limited by FPSLimit defined in this config file.
+DisableFrameSync = 0                     ; Disables the frame sync / framerate limiter altogether. This will also unlimit the game speed. Recommended to use in conjunction with GPU's FPS limiter.
+FPSLimit = 60.0                          ; Framerate limit. Game speed is also tied to this number.
 
 [SkipFE]
 Enabled = 0								 ; Enable/disable flag

--- a/source/SonicHeroes.WidescreenFix/dllmain.cpp
+++ b/source/SonicHeroes.WidescreenFix/dllmain.cpp
@@ -1,5 +1,4 @@
 #include "stdafx.h"
-#include <timeapi.h>
 
 struct Screen
 {


### PR DESCRIPTION
This is a reimplementation of the frame sync / FPS limiter function in the game.

It isn't a perfect 16.67ms for some odd reason, but it's way smoother than whatever the game ships with.

I've also included a disabler for it, so you can limit the FPS via your GPU's control panel instead for a perfect 16.67ms limit.

I'll probably iterate on this to try to make the game actually run at higher than 60FPS later, but for now this will do.