### PR TITLE
[Sonic Heroes] implement FPS limiter from d3d8-wrapper

### DIFF
--- a/data/SonicHeroes.WidescreenFix/scripts/SonicHeroes.WidescreenFix.ini
+++ b/data/SonicHeroes.WidescreenFix/scripts/SonicHeroes.WidescreenFix.ini
@@ -24,7 +24,7 @@ IncreaseObjectDistance = 1               ; Enables object visibility distance ad
 MinObjDistance = 0                       ; Minimum object distance (Min = 0, Max = 255, Default = 0)
 ObjDistanceScale = 2.0                   ; Object distance scalar. (Min = 0.0, Max = 255.0, Default = 2.0)
 BetterFrameSync = 1                      ; Improved framerate limiter with less frametime jitter. If enabled, maximum framerate will be limited by FPSLimit defined in this config file.
-DisableFrameSync = 0                     ; Disables the frame sync / framerate limiter altogether. This will also unlimit the game speed. Recommended to use in conjunction with GPU's FPS limiter.
+FPSLimitMode = 2                         ; Set the FPS limiter mode here. (0 = Disabled, 1 = Thread-Lock, 2 = Sleep-Yield (Default))
 FPSLimit = 60.0                          ; Framerate limit. Game speed is also tied to this number.
 
 [SkipFE]

--- a/source/SonicHeroes.WidescreenFix/dllmain.cpp
+++ b/source/SonicHeroes.WidescreenFix/dllmain.cpp
@@ -1334,40 +1334,6 @@ void Init()
 		uintptr_t loc_65E783 = reinterpret_cast<uintptr_t>(hook::pattern("C6 43 08 00 8B 0D ? ? ? ? 51 FF 15").get_first(0)) + 0xB;
 		uintptr_t GetClientRectIAT = *reinterpret_cast<uintptr_t*>(loc_65E783 + 2);
 		injector::WriteMemory(GetClientRectIAT, &GetClientRectHook, true);
-
-		//uintptr_t addr = 0x004460A9;
-		//injector::MakeNOP(addr, 6, true);
-		//injector::MakeCALL(addr, GetClientRectHook, true);
-		//addr = 0x655794;
-		//injector::MakeNOP(addr, 6, true);
-		//injector::MakeCALL(addr, GetClientRectHook, true);
-		//addr = 0x656644;
-		//injector::MakeNOP(addr, 6, true);
-		//injector::MakeCALL(addr, GetClientRectHook, true);
-		//addr = 0x656787;
-		//injector::MakeNOP(addr, 6, true);
-		//injector::MakeCALL(addr, GetClientRectHook, true);
-		//addr = 0x657C9C;
-		//injector::MakeNOP(addr, 6, true);
-		//injector::MakeCALL(addr, GetClientRectHook, true);
-		//addr = 0x658172;
-		//injector::MakeNOP(addr, 6, true);
-		//injector::MakeCALL(addr, GetClientRectHook, true);
-		//addr = 0x65822F;
-		//injector::MakeNOP(addr, 6, true);
-		//injector::MakeCALL(addr, GetClientRectHook, true);
-		//addr = 0x65DBE7;
-		//injector::MakeNOP(addr, 6, true);
-		//injector::MakeCALL(addr, GetClientRectHook, true);
-		//addr = 0x65DC2F;
-		//injector::MakeNOP(addr, 6, true);
-		//injector::MakeCALL(addr, GetClientRectHook, true);
-		//addr = 0x65E152;
-		//injector::MakeNOP(addr, 6, true);
-		//injector::MakeCALL(addr, GetClientRectHook, true);
-		//addr = 0x65E783;
-		//injector::MakeNOP(addr, 6, true);
-		//injector::MakeCALL(addr, GetClientRectHook, true);
 	}
 
 	if (nWindowedMode)

--- a/source/SonicHeroes.WidescreenFix/dllmain.cpp
+++ b/source/SonicHeroes.WidescreenFix/dllmain.cpp
@@ -490,37 +490,90 @@ void __stdcall TextDrawFunc2Hook(uintptr_t a1, float posX, float posY, float siz
 
 namespace BetterSync
 {
+	float fFPSLimit = 60.0f;
+
+	// code from: https://github.com/ThirteenAG/d3d8-wrapper/blob/c2509f26d22c0813bb6eced277defe67628acd90/source/dllmain.cpp#L55
+	class FrameLimiter
+	{
+	private:
+		static inline double TIME_Frequency = 0.0;
+		static inline double TIME_Ticks = 0.0;
+		static inline double TIME_Frametime = 0.0;
+
+	public:
+		enum FPSLimitMode { FPS_NONE, FPS_REALTIME, FPS_ACCURATE };
+		static void Init(FPSLimitMode mode)
+		{
+			LARGE_INTEGER frequency;
+
+			QueryPerformanceFrequency(&frequency);
+			static constexpr auto TICKS_PER_FRAME = 1;
+			auto TICKS_PER_SECOND = (TICKS_PER_FRAME * fFPSLimit);
+			if (mode == FPS_ACCURATE)
+			{
+				TIME_Frametime = 1000.0 / (double)fFPSLimit;
+				TIME_Frequency = (double)frequency.QuadPart / 1000.0; // ticks are milliseconds
+			}
+			else // FPS_REALTIME
+			{
+				TIME_Frequency = (double)frequency.QuadPart / (double)TICKS_PER_SECOND; // ticks are 1/n frames (n = fFPSLimit)
+			}
+			Ticks();
+		}
+		static DWORD Sync_RT()
+		{
+			DWORD lastTicks, currentTicks;
+			LARGE_INTEGER counter;
+
+			QueryPerformanceCounter(&counter);
+			lastTicks = (DWORD)TIME_Ticks;
+			TIME_Ticks = (double)counter.QuadPart / TIME_Frequency;
+			currentTicks = (DWORD)TIME_Ticks;
+
+			return (currentTicks > lastTicks) ? currentTicks - lastTicks : 0;
+		}
+		static DWORD Sync_SLP()
+		{
+			LARGE_INTEGER counter;
+			QueryPerformanceCounter(&counter);
+			double millis_current = (double)counter.QuadPart / TIME_Frequency;
+			double millis_delta = millis_current - TIME_Ticks;
+			if (TIME_Frametime <= millis_delta)
+			{
+				TIME_Ticks = millis_current;
+				return 1;
+			}
+			else if (TIME_Frametime - millis_delta > 2.0) // > 2ms
+				Sleep(1); // Sleep for ~1ms
+			else
+				Sleep(0); // yield thread's time-slice (does not actually sleep)
+
+			return 0;
+		}
+
+	private:
+		static void Ticks()
+		{
+			LARGE_INTEGER counter;
+			QueryPerformanceCounter(&counter);
+			TIME_Ticks = (double)counter.QuadPart / TIME_Frequency;
+		}
+	};
+
+	FrameLimiter::FPSLimitMode mFPSLimitMode = FrameLimiter::FPSLimitMode::FPS_ACCURATE;
+
 	uintptr_t sub_6C4FC0 = 0x6C4FC0;
 	uintptr_t MovieIDPtr = 0x8DB5B0;
-
-	LONGLONG FrameTimeMicrosecs = 16667;
-	LARGE_INTEGER oldTime;
 
 	void CustomSyncFunc()
 	{
 		if ((*(int32_t*)MovieIDPtr > 0))
 			return reinterpret_cast<void(*)()>(sub_6C4FC0)();
 
-		LARGE_INTEGER elapsedTime, curTime, frameTime, Frequency;
-
-		QueryPerformanceFrequency(&Frequency);
-		QueryPerformanceCounter(&curTime);
-
-		if (oldTime.QuadPart == 0)
-			oldTime.QuadPart = curTime.QuadPart;
-
-		elapsedTime.QuadPart = curTime.QuadPart - oldTime.QuadPart;
-		frameTime.QuadPart = (FrameTimeMicrosecs * Frequency.QuadPart) / 1000000;
-
-		while (elapsedTime.QuadPart < frameTime.QuadPart)
-		{
-			QueryPerformanceFrequency(&Frequency);
-			QueryPerformanceCounter(&curTime);
-			elapsedTime.QuadPart = curTime.QuadPart - oldTime.QuadPart;
-			frameTime.QuadPart = (FrameTimeMicrosecs * Frequency.QuadPart) / 1000000;
-		}
-
-		QueryPerformanceCounter(&oldTime);
+		if (mFPSLimitMode == FrameLimiter::FPSLimitMode::FPS_REALTIME)
+			while (!FrameLimiter::Sync_RT());
+		else if (mFPSLimitMode == FrameLimiter::FPSLimitMode::FPS_ACCURATE)
+			while (!FrameLimiter::Sync_SLP());
 	}
 }
 #pragma runtime_checks( "", restore )
@@ -597,8 +650,8 @@ void Init()
 	static uint8_t MinObjDistance = iniReader.ReadInteger("MISC", "MinObjDistance", 0) & 0xFF;
 	static float fObjDistanceScale = iniReader.ReadFloat("MISC", "ObjDistanceScale", 2.0f);
 	static bool bBetterFrameSync = iniReader.ReadInteger("MISC", "BetterFrameSync", 1) != 0;
-	static bool bDisableFrameSync = iniReader.ReadInteger("MISC", "DisableFrameSync", 0) != 0;
-	static float fFPSLimit = iniReader.ReadFloat("MISC", "FPSLimit", 60.0f);
+	BetterSync::mFPSLimitMode = (BetterSync::FrameLimiter::FPSLimitMode)iniReader.ReadInteger("MISC", "FPSLimitMode", BetterSync::FrameLimiter::FPSLimitMode::FPS_ACCURATE);
+	BetterSync::fFPSLimit = iniReader.ReadFloat("MISC", "FPSLimit", 60.0f);
 	
 	static auto szCustomUserFilesDirectoryInGameDir = iniReader.ReadString("MISC", "CustomUserFilesDirectoryInGameDir", "0");
 	if (szCustomUserFilesDirectoryInGameDir.empty() || szCustomUserFilesDirectoryInGameDir == "0")
@@ -1820,14 +1873,9 @@ void Init()
 		}; injector::MakeInline<ObjDrawDistanceHook>(loc_43DF60, loc_43DF60 + 0xA);
 	}
 
-	if (bDisableFrameSync)
+	if (bBetterFrameSync)
 	{
-		uintptr_t sub_6C4FC0 = reinterpret_cast<uintptr_t>(hook::pattern("68 40 42 0F 00 51 50 E8 ? ? ? ? 8B 0D").get_first(0)) - 0xE2;
-		injector::MakeRET(sub_6C4FC0);
-	}
-	else if (bBetterFrameSync)
-	{
-		BetterSync::FrameTimeMicrosecs = static_cast<LONGLONG>((1.0 / fFPSLimit) * 1e6);
+		BetterSync::FrameLimiter::Init(BetterSync::mFPSLimitMode);
 
 		BetterSync::sub_6C4FC0 = reinterpret_cast<uintptr_t>(hook::pattern("68 40 42 0F 00 51 50 E8 ? ? ? ? 8B 0D").get_first(0)) - 0xE2;		
 		BetterSync::MovieIDPtr = *(uintptr_t*)(reinterpret_cast<uintptr_t>(hook::pattern("C7 40 3C 05 00 00 00 5D C7 05 ? ? ? ? FF FF FF FF").get_first(0)) + 0xA);


### PR DESCRIPTION
Implemented this into code: https://github.com/ThirteenAG/d3d8-wrapper/pull/5

I've set Sleep-Yield as default for now. If things go haywire, return defaults to Thread-Lock instead.

I see no measurable inaccuracy between the two. Sleep-Yield is less resource intensive, so it's wiser to use that IMO.