### PR TITLE
[NFSPS] implement LAN fix for win11

### DIFF
--- a/data/NFSProStreet.GenericFix/scripts/NFSProStreet.GenericFix.ini
+++ b/data/NFSProStreet.GenericFix/scripts/NFSProStreet.GenericFix.ini
@@ -9,6 +9,7 @@ DisableAchievements = 1                  // Disables the integrated achievement 
 DisableBoosterPackThanks = 1             // Skips the booster pack / DLC thanks screen on new profiles (v1.1 and newer only)
 DisablePunkBuster = 1                    // Disables PunkBuster anti-cheat to potentially increase game stability.
 DamageMemoryLeakFix = 1                  // Fixes a memory leak in damage memory pools. Increases stability during a long play session, but also slightly increases memory requirements per-race until you exit the hub.
+Win11LANFix = 1                          // Fixes LAN mode for Windows 11 (and newer) users. (v1.1 and newer only)
 
 [MAIN]
 FixAspectRatio = 1                       // Corrects the width of the HUD, FOV, and FMVs.


### PR DESCRIPTION
Fixes LAN mode for Windows 11 users by forcing the address family to AF_INET (IPv4) (or AF_INET6 (IPv6)).

Microsoft broke AF_UNSPEC (unspecified) for whatever reason in Win11.

Note that this is a client only fix. The server itself (specifically Rebroadcaster) also needs the exact same fix.

As hooking Winsock2 is blocked by the OS, there is no choice but to patch the executable directly (or hook the C runtime). I've attached the necessary file in here as well. It needs to be placed in the ONLINE folder of the game.

[rebroadcasterlan.zip](https://github.com/ThirteenAG/WidescreenFixesPack/files/11668450/rebroadcasterlan.zip)

Furthermore - the exe was patched to re-enable console logging, so you can see what is going on exactly.

To launch a server through the console, you must first launch the "bombd" daemon like so:
`bombd -port 10104 -httpport 8080`

Then, for each game of 8 players you need to launch a rebroadcaster like this:
`rebroadcasterlan -gamename game_0 -lanport 10104`

Then for the next game:
`rebroadcasterlan -gamename game_1 -lanport 10104`

Etc.

Obviously, you're free to reconfigure the parameters to your liking (ports and gamename).
