### PR TITLE
[NFS] Improved INI file readability

### DIFF
--- a/data/NFSCarbon.WidescreenFix/scripts/NFSCarbon.WidescreenFix.ini
+++ b/data/NFSCarbon.WidescreenFix/scripts/NFSCarbon.WidescreenFix.ini
@@ -3,13 +3,13 @@ ResX = 0                                 // Use this option to control the horiz
 ResY = 0                                 // Use this option to control the vertical resolution.
 FixHUD = 1                               // Corrects HUD aspect ratio.
 FixFOV = 1                               // Corrects FOV aspect ratio.
-Scaling = 1                              // Adjusts FOV scaling. Requires FixFOV to be enabled. (0 = Original | 1 = Xbox 360 | 2 = Mathematically Correct)
+Scaling = 1                              // Adjusts FOV aspect ratio. Requires FixFOV to be enabled. (0 = Original | 1 = Xbox 360 | 2 = Mathematically Correct)
 HUDWidescreenMode = 1                    // Moves HUD to the edge of the screen for 16:9. Install NFSC HUD Adapter for other aspect ratios.
 FMVWidescreenMode = 1                    // FMVs will appear in fullscreen for 16:9. (1 = Cropped | 2 = Stretched)
 
 [MISC]
 SkipIntro = 0                            // Skips FMVs that play when you launch the game.
-WindowedMode = 0                         // Enables windowed mode. (1 = Borderless Windowed | 2 = Border | 3 = Border with resizing | 4 = Borderless Fullscreen | 5 = Borderless Fullscreen (Stretched))
+WindowedMode = 0                         // Enables windowed mode. (1 = Borderless | 2 = Border | 3 = Resizable Border | 4 = Borderless Fullscreen | 5 = Borderless Fullscreen Stretched)
 LightingFix = 1                          // Adjusts lighting to match the Xbox 360 version.
 CarShadowFix = 1                         // Reduces shadow opacity to match the Xbox 360 version.
 CustomUserFilesDirectoryInGameDir = 0    // User files will be stored in a specified directory (for example: "save"). Use '0' to disable.
@@ -18,13 +18,13 @@ CrashFix = 1                             // Solves an issue that caused the game
 ImproveGamepadSupport = 0                // Replaces keyboard icons with gamepad icons and assigns front-end actions. Requires an XInput gamepad. (1 = Xbox Icons | 2 = PlayStation Icons | 3 = None)
 ExpandControllerOptions = 0              // Lists all 29 options in the controller config menu. Will only work with new profiles, existing profiles will crash.
 LeftStickDeadzone = 10.0                 // Controls the deadzone of the left analog stick.
-SimRate = -1                             // Control the refresh rate of the gameplay engine. Affects overall smoothness. Best to match with monitor refresh or your target FPS. (0 = Disable patches | -1 = Primary monitor refresh rate (DEFAULT) | -2 = 2x primary monitor refresh)
 DisableMotionBlur = 0                    // Allows users to disable motion blur without changing registry settings and without losing other effects (such as screen flashes or light trails).
 DisableContrails = 0                     // Disables the wind effect behind the car.
 FixXenonEffects = 1                      // Fixes the alpha blending state of sparks and contrails. Disable this if you want to modify the texture properties.
+SimRate = -1                             // Controls the refresh rate of the gameplay engine. Match your monitor's refresh rate or your target frame rate. (0 = Disabled | -1 = Monitor Refresh Rate | -2 = Double Monitor Refresh Rate)
 
 [NOSTrail]
-FixNOSTrailLength = 1                    // Attempt to fix the NOS trail length for higher FPS.
-CustomNOSTrailLength = 1.0               // Adjust the total distance of the NOS trail. You may need to adjust this if you're playing at very high FPS (240+). Higher the SimRate vs render FPS difference, longer the trail, and the longer the trail, less aligned it becomes with the car.
-FixNOSTrailPosition = 0                  // If FixNOSTrailLength is enabled, this will attempt to fix the NOS trail position from clipping with the car by scaling its position away from the car.
-NOSTrailPositionScalar = 0.3             // If FixNOSTrailPosition is enabled, this will adjust the trail's position away from the car's tail lights.
+FixNOSTrailLength = 1                    // Fixes the NOS trail length for higher FPS.
+CustomNOSTrailLength = 1.0               // Adjusts the total distance of the NOS trail. You may need to adjust this if you're playing at very high FPS (240+). The higher the SimRate & FPS difference, the longer the trail.
+FixNOSTrailPosition = 0                  // Requires FixNOSTrailLength to be enabled. This will attempt to fix the trail from clipping the car by scaling its position away from the car.
+NOSTrailPositionScalar = 0.3             // Requires FixNOSTrailPosition to be enabled. This controls the trail position relative to the tail lights.

--- a/data/NFSMostWanted.WidescreenFix/scripts/NFSMostWanted.WidescreenFix.ini
+++ b/data/NFSMostWanted.WidescreenFix/scripts/NFSMostWanted.WidescreenFix.ini
@@ -3,28 +3,27 @@ ResX = 0                                 // Use this option to control the horiz
 ResY = 0                                 // Use this option to control the vertical resolution.
 FixHUD = 1                               // Corrects HUD aspect ratio.
 FixFOV = 1                               // Corrects FOV aspect ratio.
-Scaling = 1                              // Adjusts FOV scaling. Requires FixFOV to be enabled. (0 = Original | 1 = Xbox 360 | 2 = Mathematically Correct)
+Scaling = 1                              // Adjusts FOV aspect ratio. Requires FixFOV to be enabled. (0 = Original | 1 = Xbox 360 | 2 = Mathematically Correct)
 HUDWidescreenMode = 1                    // Moves HUD to the edge of the screen for 16:9. Install NFSMW HUD Adapter for other aspect ratios.
 FMVWidescreenMode = 1                    // FMVs will appear in fullscreen for 16:9. (1 = Cropped | 2 = Stretched)
 
 [MISC]
 SkipIntro = 0                            // Skips FMVs that play when you launch the game.
-WindowedMode = 0                         // Enables windowed mode. (1 = Borderless Windowed | 2 = Border | 3 = Border with dynamic resizing | 4 = Borderless Fullscreen | 5 = Borderless Fullscreen (Stretched))
-ShadowsRes = 1024                        // Controls the resolution of dynamic shadows and enables them for Intel GPUs. (1024 = Default | 2048 = Xbox 360)
+WindowedMode = 0                         // Enables windowed mode. (1 = Borderless | 2 = Border | 3 = Resizable Border | 4 = Borderless Fullscreen | 5 = Borderless Fullscreen Stretched)
+ShadowsRes = 1024                        // Controls the resolution of dynamic shadows and enables them for Intel GPUs. (1024 = Original | 2048 = Xbox 360)
 AutoScaleShadowsRes = 0                  // Adjusts the specified ShadowsRes based on the user's aspect ratio to maintain quality. This may negatively affect performance.
 ShadowsFix = 1                           // Dynamic shadows will no longer disappear when going into tunnels, under bridges, etc.
 ImproveShadowLOD = 0                     // Increases the level of detail of dynamic shadows. This may negatively affect performance.
-ForceEnableMirror = 1                    // Rearview mirror will be visible for all camera views.
 CustomUserFilesDirectoryInGameDir = 0    // User files will be stored in a specified directory (for example: "save"). Use '0' to disable.
 WriteSettingsToFile = 0                  // All registry settings will be saved to "settings.ini" in your profile folder. You must input your CD key and langauge in "settings.ini" when this option is enabled.
 ImproveGamepadSupport = 0                // Replaces keyboard icons with gamepad icons and assigns front-end actions. Requires an XInput gamepad. (1 = Xbox Icons | 2 = PlayStation Icons | 3 = None)
 LeftStickDeadzone = 10.0                 // Controls the deadzone of the left analog stick.
 ForceHighSpecAudio = 1                   // Enables 44100Hz sample rate audio regardless of registry settings.
-SimRate = -1                             // Control the refresh rate of the gameplay engine. Affects overall smoothness. Best to match with monitor refresh or your target FPS. (0 = Disable patches | -1 = Primary monitor refresh rate (DEFAULT) | -2 = 2x primary monitor refresh)
 DisableMotionBlur = 0                    // Allows users to disable motion blur without changing registry settings.
+SimRate = -1                             // Controls the refresh rate of the gameplay engine. Match your monitor's refresh rate or your target frame rate. (0 = Disabled | -1 = Monitor Refresh Rate | -2 = Double Monitor Refresh Rate)
 
 [NOSTrail]
-FixNOSTrailLength = 1                    // Attempt to fix the NOS trail length for higher FPS.
-CustomNOSTrailLength = 1.0               // Adjust the total distance of the NOS trail. You may need to adjust this if you're playing at very high FPS (240+). Higher the SimRate vs render FPS difference, longer the trail, and the longer the trail, less aligned it becomes with the car.
-FixNOSTrailPosition = 0                  // If FixNOSTrailLength is enabled, this will attempt to fix the NOS trail position from clipping with the car by scaling its position away from the car.
-NOSTrailPositionScalar = 0.3             // If FixNOSTrailPosition is enabled, this will adjust the trail's position away from the car's tail lights.
+FixNOSTrailLength = 1                    // Fixes the NOS trail length for higher FPS.
+CustomNOSTrailLength = 1.0               // Adjusts the total distance of the NOS trail. You may need to adjust this if you're playing at very high FPS (240+). The higher the SimRate & FPS difference, the longer the trail.
+FixNOSTrailPosition = 0                  // Requires FixNOSTrailLength to be enabled. This will attempt to fix the trail from clipping the car by scaling its position away from the car.
+NOSTrailPositionScalar = 0.3             // Requires FixNOSTrailPosition to be enabled. This controls the trail position relative to the tail lights.

--- a/data/NFSProStreet.GenericFix/scripts/NFSProStreet.GenericFix.ini
+++ b/data/NFSProStreet.GenericFix/scripts/NFSProStreet.GenericFix.ini
@@ -1,33 +1,33 @@
 [MultiFix]
-ShowConsole = 0                          // Enables the console window
-ResDetect = 1                            // Adds resolution auto-detection for the ingame options menu.
-PostRaceFix = 1                          // Fixes the post race screen from being stuck (continue button bug fix) (v1.1 and newer only)
-FramerateUncap = 1                       // Unlimits the framerate (v1.1 and newer only)
-AntiTrackStreamerCrash = 1               // Adds memory checks for the TrackStreamer
-AntiFEScriptCrash = 1                    // Adds memory checks for FE::Object::SetScript
-DisableAchievements = 1                  // Disables the integrated achievement system. Potentially increases game stability. These are not normally visible in the PC version. (v1.1 and newer only)
+ShowConsole = 0                          // Enables the console window on launch.
+ResDetect = 1                            // Adds resolution auto-detection for the in-game options menu.
+PostRaceFix = 1                          // Prevents the post race screen from getting stuck on the "Continue" button. (v1.1 and newer only)
+FramerateUncap = 1                       // Unlocks the frame rate. (v1.1 and newer only)
+AntiTrackStreamerCrash = 1               // Adds memory checks for the TrackStreamer.
+AntiFEScriptCrash = 1                    // Adds memory checks for FE::Object::SetScript.
+DisableAchievements = 1                  // Disables the integrated achievement system that is unused in the PC version. Potentially increases game stability. (v1.1 and newer only)
 DisableBoosterPackThanks = 1             // Skips the booster pack / DLC thanks screen on new profiles (v1.1 and newer only)
-DisablePunkBuster = 1                    // Disables PunkBuster anti-cheat to potentially increase game stability.
+DisablePunkBuster = 1                    // Disables PunkBuster anti-cheat. Potentially increases game stability.
 DamageMemoryLeakFix = 1                  // Fixes a memory leak in damage memory pools. Increases stability during a long play session, but also slightly increases memory requirements per-race until you exit the hub.
-Win11LANFix = 1                          // Fixes LAN mode for Windows 11 (and newer) users. (v1.1 and newer only)
+Win11LANFix = 1                          // Fixes LAN mode for people using Windows 11 and newer. (v1.1 and newer only)
 
 [MAIN]
 FixAspectRatio = 1                       // Corrects the width of the HUD, FOV, and FMVs.
-Scaling = 1                              // Adjusts FOV scaling. Requires FixAspectRatio to be enabled. (0 = Original | 1 = Xbox 360 | 2 = Mathematically Correct)
+Scaling = 1                              // Adjusts FOV aspect ratio. Requires FixAspectRatio to be enabled. (0 = Original | 1 = Xbox 360 | 2 = Mathematically Correct)
 FMVWidescreenMode = 1                    // FMVs will appear in fullscreen. Requires FixAspectRatio to be enabled.
 ConsoleHUDSize = 0                       // Makes the HUD smaller like the console version.
 
 [MISC]
 SkipIntro = 0                            // Skips FMVs that play when you launch the game.
-SkipFEBootflow = 0                       // Skips the entire bootflow process and goes straight to main menu. Useful for skipping boot screens in the demo version. WARNING: You cannot load your alias if this is enabled!
-WindowedMode = 0                         // Enables windowed mode. (1 = Borderless Windowed | 2 = Border | 3 = Border with resizing | 4 = Borderless Fullscreen | 5 = Borderless Fullscreen (Stretched))
+SkipFEBootflow = 0                       // Skips the entire bootflow process and goes straight to the main menu. WARNING: You cannot load your alias if this is enabled!
+WindowedMode = 0                         // Enables windowed mode. (1 = Borderless | 2 = Border | 3 = Resizable Border | 4 = Borderless Fullscreen | 5 = Borderless Fullscreen Stretched)
 CustomUserFilesDirectoryInGameDir = 0    // User files will be stored in a specified directory (for example: "save"). Use '0' to disable.
 WriteSettingsToFile = 0                  // All registry settings will be saved to "settings.ini" in your profile folder. You must input your CD key and langauge in "settings.ini" when this option is enabled.
-ImproveGamepadSupport = 0                // Replaces keyboard icons with gamepad icons and assigns front-end actions. Requires an XInput gamepad. NOTE: It does not work if XtendedInput is installed. (1 = Xbox Icons | 2 = PlayStation Icons | 3 = None)
+ImproveGamepadSupport = 0                // Replaces keyboard icons with gamepad icons and assigns front-end actions. Requires an XInput gamepad. (1 = Xbox Icons | 2 = PlayStation Icons | 3 = None)
 LeftStickDeadzone = 10.0                 // Controls the deadzone of the left analog stick.
 BrakeLightFix = 1                        // Solves an issue that caused brake lights to only work when ABS was active.
 GammaFix = 1                             // Solves an issue that caused the wrong brightness value to be used on launch.
-ShadowRes = 2048                         // Controls the resolution of dynamic shadows. (2048 = Default) 
-SimRate = -1                             // Control the refresh rate of the gameplay engine. Affects overall smoothness. Best to match with monitor refresh or your target FPS. (0 = Disable patches | -1 = Primary monitor refresh rate (DEFAULT) | -2 = 2x primary monitor refresh)
+ShadowRes = 2048                         // Controls the resolution of dynamic shadows. (2048 = Original) 
 DisableMotionBlur = 0                    // Disables motion blur without affecting the World FX setting.
 FixXenonEffects = 1                      // Fixes the alpha blending state of sparks. Disable this if you want to modify the texture properties.
+SimRate = -1                             // Controls the refresh rate of the gameplay engine. Match your monitor's refresh rate or your target frame rate. (0 = Disabled | -1 = Monitor Refresh Rate | -2 = Double Monitor Refresh Rate)

--- a/data/NFSUndercover.GenericFix/scripts/NFSUndercover.GenericFix.ini
+++ b/data/NFSUndercover.GenericFix/scripts/NFSUndercover.GenericFix.ini
@@ -2,7 +2,7 @@
 ResDetect = 1                            // Adds resolution auto-detection for the in-game options menu.
 
 [MAIN]
-Scaling = 1                              // Adjusts FOV aspect ratio. (0 = Original | 1 = Xbox 360 | 2 = Mathematically Correct)
+Scaling = 0                              // Adjusts FOV aspect ratio to be mathematically correct. Requires FixFOV to be enabled.
 
 [MISC]
 SkipIntro = 0                            // Skips FMVs that play when you launch the game.

--- a/data/NFSUndercover.GenericFix/scripts/NFSUndercover.GenericFix.ini
+++ b/data/NFSUndercover.GenericFix/scripts/NFSUndercover.GenericFix.ini
@@ -1,12 +1,12 @@
 [MultiFix]
-ResDetect = 1
+ResDetect = 1                            // Adds resolution auto-detection for the in-game options menu.
 
 [MAIN]
-Scaling = 0                              // Adjusts FOV scaling to be mathematically correct.
+Scaling = 1                              // Adjusts FOV aspect ratio. (0 = Original | 1 = Xbox 360 | 2 = Mathematically Correct)
 
 [MISC]
 SkipIntro = 0                            // Skips FMVs that play when you launch the game.
-WindowedMode = 0                         // Enables windowed mode. (1 = Borderless Windowed | 2 = Border | 3 = Border with resizing | 4 = Borderless Fullscreen | 5 = Borderless Fullscreen (Stretched))
+WindowedMode = 0                         // Enables windowed mode. (1 = Borderless | 2 = Border | 3 = Resizable Border | 4 = Borderless Fullscreen | 5 = Borderless Fullscreen Stretched)
 CustomUserFilesDirectoryInGameDir = 0    // User files will be stored in a specified directory (for example: "save"). Use '0' to disable.
 WriteSettingsToFile = 0                  // All registry settings will be saved to "settings.ini" in your profile folder. You must input your CD key and langauge in "settings.ini" when this option is enabled.
 ImproveGamepadSupport = 0                // Replaces keyboard icons with gamepad icons and assigns front-end actions. Requires an XInput gamepad. (1 = Xbox Icons | 2 = PlayStation Icons | 3 = None)
@@ -14,13 +14,13 @@ LeftStickDeadzone = 10.0                 // Controls the deadzone of the left an
 
 [GRAPHICS]
 BloomIntensity = 1.0                     // Default (1.0): https://i.imgur.com/pQYfBzA.jpg | Disabled (0.0): https://i.imgur.com/A4MKLyS.jpg
-ShadowsRes = 8192                        // Controls the resolution of dynamic shadows. Shadow map contains up to 3 cascades on the X axis. Resulting resolution will be multiplied by the number of cascades on the X axis. (8192 = Default | 1024 = Game Default | 16384 = Max)
-CSMScale = 1.0                           // Overall scale of the cascade shadow map. Larger the number, greater the draw distance, but the quality is lower. The same applies to the values below. (1.0 = Default)
-CSMScaleNear = 100.0                     // Nearest cascade (100.0 = Default | 5.0 = Game Default)
-CSMScaleMid = 175.0                      // Mid cascade (175.0 = Default | 30.0 = Game Default)
-CSMScaleFar = 300.0                      // Far cascade (300.0 = Default | 170.0 = Game Default)
+ShadowsRes = 8192                        // Controls the resolution of dynamic shadows. (8192 = Default | 1024 = Original | 16384 = Max)
+CSMScale = 1.0                           // Overall scale of the cascade shadow map. Larger the number, the greater the draw distance, but the lower the quality. (1.0 = Default)
+CSMScaleNear = 100.0                     // Nearest cascade (100.0 = Default | 5.0 = Original)
+CSMScaleMid = 175.0                      // Mid cascade (175.0 = Default | 30.0 = Original)
+CSMScaleFar = 300.0                      // Far cascade (300.0 = Default | 170.0 = Original)
 ImproveSceneryLOD = 0                    // Increases visible scenery on screen. Increases visible scenery in the closest map section, but may cause flickering for the farther ones.
-DisablePreculler = 0                     // Disables the preculler. (precalculated culling)
-BruteforceCulling = 0                    // Forces the game to use bruteforced culling type instead of TreeCull. This can decrease culled scenery (especially out of bounds), but may increase flicker.
-SimRate = -1                             // Control the refresh rate of the gameplay engine. Affects overall smoothness. Best to match with monitor refresh or your target FPS. (0 = Disable patches | -1 = Primary monitor refresh rate (DEFAULT) | -2 = 2x primary monitor refresh)
+DisablePreculler = 0                     // Disables precalculated culling.
+BruteforceCulling = 0                    // Forces the game to use bruteforced culling type instead of TreeCull. This can decrease culled scenery, but may increase flicker.
+SimRate = -1                             // Controls the refresh rate of the gameplay engine. Match your monitor's refresh rate or your target frame rate. (0 = Disabled | -1 = Monitor Refresh Rate | -2 = Double Monitor Refresh Rate)
 DisableMotionBlur = 0                    // Disables motion blur without affecting the World FX setting.

--- a/data/NFSUnderground.WidescreenFix/scripts/NFSUnderground.WidescreenFix.ini
+++ b/data/NFSUnderground.WidescreenFix/scripts/NFSUnderground.WidescreenFix.ini
@@ -3,16 +3,16 @@ ResX = 0                                 // Use this option to control the horiz
 ResY = 0                                 // Use this option to control the vertical resolution.
 FixHUD = 1                               // Corrects HUD aspect ratio.
 FixFOV = 1                               // Corrects FOV aspect ratio.
-Scaling = 0                              // Adjusts FOV scaling to be mathematically correct. Requires FixFOV to be enabled.
+Scaling = 0                              // Adjusts FOV aspect ratio to be mathematically correct. Requires FixFOV to be enabled.
 HUDWidescreenMode = 1                    // Moves HUD to the edge of the screen. Change offset in "NFSUnderground.WidescreenFix.dat" file for other aspect ratios.
 FMVWidescreenMode = 1                    // FMVs will appear in fullscreen for 16:9. (1 = Cropped | 2 = Stretched)
 
 [MISC]
 SkipIntro = 0                            // Skips FMVs that play when you launch the game.
-WindowedMode = 0                         // Enables windowed mode. (1 = Borderless Windowed | 2 = Border | 3 = Border with resizing | 4 = Borderless Fullscreen | 5 = Borderless Fullscreen (Stretched))
-HideDebugObjects = 1                     // Hides debug objects. (1 = Removed by code | 2 = Adds borders to the front-end)
+WindowedMode = 0                         // Enables windowed mode. (1 = Borderless | 2 = Border | 3 = Resizable Border | 4 = Borderless Fullscreen | 5 = Borderless Fullscreen Stretched)
+HideDebugObjects = 1                     // Hides debug objects. (1 = Remove Objects | 2 = Hide Objects with Pillarboxing)
 CustomUserFilesDirectoryInGameDir = 0    // User files will be stored in a specified directory (for example: "save"). Use '0' to disable.
 ImproveGamepadSupport = 0                // Replaces keyboard icons with gamepad icons and assigns front-end actions. Requires an XInput gamepad. (1 = Xbox Icons | 2 = PlayStation Icons | 3 = None)
 LeftStickDeadzone = 10.0                 // Controls the deadzone of the left analog stick.
-FPSLimit = -1                            // Allows users to control the framerate limit. (0 = Disable patches | -1 = Primary monitor refresh rate (DEFAULT) | -2 = 2x primary monitor refresh)
+FPSLimit = -1                            // Allows users to control the frame rate limit. (0 = Disabled | -1 = Monitor Refresh Rate | -2 = Double Monitor Refresh Rate)
 BlackMagazineFix = 0                     // Fixes black background in magazine covers. May not be compatible with all versions of the game.

--- a/data/NFSUnderground2.WidescreenFix/scripts/NFSUnderground2.WidescreenFix.ini
+++ b/data/NFSUnderground2.WidescreenFix/scripts/NFSUnderground2.WidescreenFix.ini
@@ -3,22 +3,22 @@ ResX = 0                                 // Use this option to control the horiz
 ResY = 0                                 // Use this option to control the vertical resolution.
 FixHUD = 1                               // Corrects HUD aspect ratio.
 FixFOV = 1                               // Corrects FOV aspect ratio.
-Scaling = 0                              // Adjusts FOV scaling to be mathematically correct. Requires FixFOV to be enabled.
+Scaling = 0                              // Adjusts FOV aspect ratio to be mathematically correct. Requires FixFOV to be enabled.
 HUDWidescreenMode = 1                    // Moves HUD to the edge of the screen. Change offset in "NFSUnderground2.WidescreenFix.dat" file for other aspect ratios.
 FMVWidescreenMode = 1                    // FMVs will appear in fullscreen for 16:9. (1 = Cropped | 2 = Stretched)
 
 [MISC]
 SkipIntro = 0                            // Skips FMVs that play when you launch the game.
-WindowedMode = 0                         // Enables windowed mode. (1 = Borderless Windowed | 2 = Border | 3 = Border with resizing | 4 = Borderless Fullscreen | 5 = Borderless Fullscreen (Stretched))
+WindowedMode = 0                         // Enables windowed mode. (1 = Borderless | 2 = Border | 3 = Resizable Border | 4 = Borderless Fullscreen | 5 = Borderless Fullscreen Stretched)
 DisableCutsceneBorders = 1               // Removes letterboxing that appears during cutscenes.
 CustomUserFilesDirectoryInGameDir = 0    // User files will be stored in a specified directory (for example: "save"). Use '0' to disable.
 WriteSettingsToFile = 0                  // All registry settings will be saved to "settings.ini" in your profile folder. You must input your CD key and langauge in "settings.ini" when this option is enabled.
 ImproveGamepadSupport = 0                // Adds text to buttons and assigns front-end actions. Requires an XInput gamepad. (1 = Xbox Text | 2 = PlayStation Text | 3 = PC Text | 4 = None)
 LeftStickDeadzone = 10.0                 // Controls the deadzone of the left analog stick.
-FPSLimit = -1                            // Allows users to control the framerate limit. (0 = Disable patches | -1 = Primary monitor refresh rate (DEFAULT) | -2 = 2x primary monitor refresh)
-HighFPSCutscenes = 1                     // Increases the framerate limit for cutscenes to the nearest multiple of 30 (maximum is currently 60 due to bugs)
+FPSLimit = -1                            // Allows users to control the frame rate limit. (0 = Disabled | -1 = Monitor Refresh Rate | -2 = Double Monitor Refresh Rate)
+HighFPSCutscenes = 1                     // Increases the frame rate limit for cutscenes to the nearest multiple of 30 (maximum is currently 60 due to bugs)
 SingleCoreAffinity = 1                   // Limits game to one CPU core to prevent crashing.
 
 [NOSTrail]
-FixNOSTrailLength = 1                    // Attempt to fix the NOS trail length for higher FPS.
-CustomNOSTrailLength = 1.0               // Adjust the total distance of the NOS trail. You may need to adjust this if you're playing at very high FPS (240+). Higher the FPSLimit vs render FPS difference, longer the trail.
+FixNOSTrailLength = 1                    // Fixes the NOS trail length for higher FPS.
+CustomNOSTrailLength = 1.0               // Adjusts the total distance of the NOS trail. You may need to adjust this if you're playing at very high FPS (240+). The higher the SimRate & FPS difference, the longer the trail.

--- a/source/NFSMostWanted.WidescreenFix/dllmain.cpp
+++ b/source/NFSMostWanted.WidescreenFix/dllmain.cpp
@@ -212,7 +212,6 @@ void Init()
     bool bAutoScaleShadowsRes = iniReader.ReadInteger("MISC", "AutoScaleShadowsRes", 0) != 0;
     bool bShadowsFix = iniReader.ReadInteger("MISC", "ShadowsFix", 1) != 0;
     bool bImproveShadowLOD = iniReader.ReadInteger("MISC", "ImproveShadowLOD", 0) != 0;
-    bool bForceEnableMirror = iniReader.ReadInteger("MISC", "ForceEnableMirror", 1) == 1;
     static auto szCustomUserFilesDirectoryInGameDir = iniReader.ReadString("MISC", "CustomUserFilesDirectoryInGameDir", "");
     bool bWriteSettingsToFile = iniReader.ReadInteger("MISC", "WriteSettingsToFile", 1) != 0;
     static int nImproveGamepadSupport = iniReader.ReadInteger("MISC", "ImproveGamepadSupport", 0);
@@ -620,17 +619,6 @@ void Init()
         //car shadow opacity
         uint32_t* dword_8A0E50 = *hook::pattern("D9 05 ? ? ? ? 8B 54 24 70 D9 1A E9 D1").count(1).get(0).get<uint32_t*>(2);
         injector::WriteMemory(dword_8A0E50, 60.0f, true);
-    }
-
-    if (bForceEnableMirror)
-    {
-        //Enables mirror for all camera views
-        uint32_t* dword_6CFB72 = hook::pattern("75 66 53 E8 ? ? ? ? 83 C4 04 84 C0 74 59").count(1).get(0).get<uint32_t>(0);
-        injector::MakeNOP(dword_6CFB72, 2, true);
-        uint32_t* dword_6CFBC5 = hook::pattern("75 0D 53 E8 ? ? ? ? 83 C4 04 84 C0 75 06 89 1D").count(1).get(0).get<uint32_t>(0);
-        injector::MakeNOP(dword_6CFBC5, 2, true);
-        uint32_t* dword_595DDD = hook::pattern("83 F8 02 ? ? 83 F8 03 ? ? 83 F8 04 ? ? 83 F8 05 ? ? 83 F8 06 ? ?").count(1).get(0).get<uint32_t>(3);
-        injector::WriteMemory<uint16_t>(dword_595DDD, 0x14EB, true); // jmp 00595DF3
     }
 
     if (bForceHighSpecAudio)

--- a/source/NFSProStreet.GenericFix/dllmain.cpp
+++ b/source/NFSProStreet.GenericFix/dllmain.cpp
@@ -1265,7 +1265,7 @@ void Init()
             RegistryWrapper::AddDefault("g_ShadowEnable", "3");
             RegistryWrapper::AddDefault("g_ShaderDetailLevel", "1");
             RegistryWrapper::AddDefault("g_AudioDetail", "1");
-            RegistryWrapper::AddDefault("g_Brightness", "68");
+            RegistryWrapper::AddDefault("g_Brightness", "50");
             RegistryWrapper::AddDefault("g_AudioMode", "1");
             RegistryWrapper::AddDefault("g_Width", std::to_string(DesktopResW));
             RegistryWrapper::AddDefault("g_Height", std::to_string(DesktopResH));


### PR DESCRIPTION
[NFS]
- Improved the INI file readability for all of the new features that were added.

[NFSPS]
- Changed the default registry brightness value from 68 to 50. This was causing the game to appear washed out when `WriteSettingsToFile` was used.

[NFSMW]
- Removed `ForceEnableMirror` since this feature is now redundant with existence of the HD Reflections mod.