### PR TITLE
[NFS] update ini comment markers

### DIFF
--- a/data/NFSCarbon.WidescreenFix/scripts/NFSCarbon.WidescreenFix.ini
+++ b/data/NFSCarbon.WidescreenFix/scripts/NFSCarbon.WidescreenFix.ini
@@ -1,30 +1,30 @@
 [MAIN]
-ResX = 0                                 // Use this option to control the horizontal resolution.
-ResY = 0                                 // Use this option to control the vertical resolution.
-FixHUD = 1                               // Corrects HUD aspect ratio.
-FixFOV = 1                               // Corrects FOV aspect ratio.
-Scaling = 1                              // Adjusts FOV aspect ratio. Requires FixFOV to be enabled. (0 = Original | 1 = Xbox 360 | 2 = Mathematically Correct)
-HUDWidescreenMode = 1                    // Moves HUD to the edge of the screen for 16:9. Install NFSC HUD Adapter for other aspect ratios.
-FMVWidescreenMode = 1                    // FMVs will appear in fullscreen for 16:9. (1 = Cropped | 2 = Stretched)
+ResX = 0                                 ; Use this option to control the horizontal resolution.
+ResY = 0                                 ; Use this option to control the vertical resolution.
+FixHUD = 1                               ; Corrects HUD aspect ratio.
+FixFOV = 1                               ; Corrects FOV aspect ratio.
+Scaling = 1                              ; Adjusts FOV aspect ratio. Requires FixFOV to be enabled. (0 = Original | 1 = Xbox 360 | 2 = Mathematically Correct)
+HUDWidescreenMode = 1                    ; Moves HUD to the edge of the screen for 16:9. Install NFSC HUD Adapter for other aspect ratios.
+FMVWidescreenMode = 1                    ; FMVs will appear in fullscreen for 16:9. (1 = Cropped | 2 = Stretched)
 
 [MISC]
-SkipIntro = 0                            // Skips FMVs that play when you launch the game.
-WindowedMode = 0                         // Enables windowed mode. (1 = Borderless | 2 = Border | 3 = Resizable Border | 4 = Borderless Fullscreen | 5 = Borderless Fullscreen Stretched)
-LightingFix = 1                          // Adjusts lighting to match the Xbox 360 version.
-CarShadowFix = 1                         // Reduces shadow opacity to match the Xbox 360 version.
-CustomUserFilesDirectoryInGameDir = 0    // User files will be stored in a specified directory (for example: "save"). Use '0' to disable.
-WriteSettingsToFile = 0                  // All registry settings will be saved to "settings.ini" in your profile folder. You must input your CD key and langauge in "settings.ini" when this option is enabled.
-CrashFix = 1                             // Solves an issue that caused the game to crash after loading a profile.
-ImproveGamepadSupport = 0                // Replaces keyboard icons with gamepad icons and assigns front-end actions. Requires an XInput gamepad. (1 = Xbox Icons | 2 = PlayStation Icons | 3 = None)
-ExpandControllerOptions = 0              // Lists all 29 options in the controller config menu. Will only work with new profiles, existing profiles will crash.
-LeftStickDeadzone = 10.0                 // Controls the deadzone of the left analog stick.
-DisableMotionBlur = 0                    // Allows users to disable motion blur without changing registry settings and without losing other effects (such as screen flashes or light trails).
-DisableContrails = 0                     // Disables the wind effect behind the car.
-FixXenonEffects = 1                      // Fixes the alpha blending state of sparks and contrails. Disable this if you want to modify the texture properties.
-SimRate = -1                             // Controls the refresh rate of the gameplay engine. Match your monitor's refresh rate or your target frame rate. (0 = Disabled | -1 = Monitor Refresh Rate | -2 = Double Monitor Refresh Rate)
+SkipIntro = 0                            ; Skips FMVs that play when you launch the game.
+WindowedMode = 0                         ; Enables windowed mode. (1 = Borderless | 2 = Border | 3 = Resizable Border | 4 = Borderless Fullscreen | 5 = Borderless Fullscreen Stretched)
+LightingFix = 1                          ; Adjusts lighting to match the Xbox 360 version.
+CarShadowFix = 1                         ; Reduces shadow opacity to match the Xbox 360 version.
+CustomUserFilesDirectoryInGameDir = 0    ; User files will be stored in a specified directory (for example: "save"). Use '0' to disable.
+WriteSettingsToFile = 0                  ; All registry settings will be saved to "settings.ini" in your profile folder. You must input your CD key and langauge in "settings.ini" when this option is enabled.
+CrashFix = 1                             ; Solves an issue that caused the game to crash after loading a profile.
+ImproveGamepadSupport = 0                ; Replaces keyboard icons with gamepad icons and assigns front-end actions. Requires an XInput gamepad. (1 = Xbox Icons | 2 = PlayStation Icons | 3 = None)
+ExpandControllerOptions = 0              ; Lists all 29 options in the controller config menu. Will only work with new profiles, existing profiles will crash.
+LeftStickDeadzone = 10.0                 ; Controls the deadzone of the left analog stick.
+DisableMotionBlur = 0                    ; Allows users to disable motion blur without changing registry settings and without losing other effects (such as screen flashes or light trails).
+DisableContrails = 0                     ; Disables the wind effect behind the car.
+FixXenonEffects = 1                      ; Fixes the alpha blending state of sparks and contrails. Disable this if you want to modify the texture properties.
+SimRate = -1                             ; Controls the refresh rate of the gameplay engine. Match your monitor's refresh rate or your target frame rate. (0 = Disabled | -1 = Monitor Refresh Rate | -2 = Double Monitor Refresh Rate)
 
 [NOSTrail]
-FixNOSTrailLength = 1                    // Fixes the NOS trail length for higher FPS.
-CustomNOSTrailLength = 1.0               // Adjusts the total distance of the NOS trail. You may need to adjust this if you're playing at very high FPS (240+). The higher the SimRate & FPS difference, the longer the trail.
-FixNOSTrailPosition = 0                  // Requires FixNOSTrailLength to be enabled. This will attempt to fix the trail from clipping the car by scaling its position away from the car.
-NOSTrailPositionScalar = 0.3             // Requires FixNOSTrailPosition to be enabled. This controls the trail position relative to the tail lights.
+FixNOSTrailLength = 1                    ; Fixes the NOS trail length for higher FPS.
+CustomNOSTrailLength = 1.0               ; Adjusts the total distance of the NOS trail. You may need to adjust this if you're playing at very high FPS (240+). The higher the SimRate & FPS difference, the longer the trail.
+FixNOSTrailPosition = 0                  ; Requires FixNOSTrailLength to be enabled. This will attempt to fix the trail from clipping the car by scaling its position away from the car.
+NOSTrailPositionScalar = 0.3             ; Requires FixNOSTrailPosition to be enabled. This controls the trail position relative to the tail lights.

--- a/data/NFSProStreet.GenericFix/scripts/NFSProStreet.GenericFix.ini
+++ b/data/NFSProStreet.GenericFix/scripts/NFSProStreet.GenericFix.ini
@@ -1,33 +1,33 @@
 [MultiFix]
-ShowConsole = 0                          // Enables the console window on launch.
-ResDetect = 1                            // Adds resolution auto-detection for the in-game options menu.
-PostRaceFix = 1                          // Prevents the post race screen from getting stuck on the "Continue" button. (v1.1 and newer only)
-FramerateUncap = 1                       // Unlocks the frame rate. (v1.1 and newer only)
-AntiTrackStreamerCrash = 1               // Adds memory checks for the TrackStreamer.
-AntiFEScriptCrash = 1                    // Adds memory checks for FE::Object::SetScript.
-DisableAchievements = 1                  // Disables the integrated achievement system that is unused in the PC version. Potentially increases game stability. (v1.1 and newer only)
-DisableBoosterPackThanks = 1             // Skips the booster pack / DLC thanks screen on new profiles (v1.1 and newer only)
-DisablePunkBuster = 1                    // Disables PunkBuster anti-cheat. Potentially increases game stability.
-DamageMemoryLeakFix = 1                  // Fixes a memory leak in damage memory pools. Increases stability during a long play session, but also slightly increases memory requirements per-race until you exit the hub.
-Win11LANFix = 1                          // Fixes LAN mode for people using Windows 11 and newer. (v1.1 and newer only)
+ShowConsole = 0                          ; Enables the console window on launch.
+ResDetect = 1                            ; Adds resolution auto-detection for the in-game options menu.
+PostRaceFix = 1                          ; Prevents the post race screen from getting stuck on the "Continue" button. (v1.1 and newer only)
+FramerateUncap = 1                       ; Unlocks the frame rate. (v1.1 and newer only)
+AntiTrackStreamerCrash = 1               ; Adds memory checks for the TrackStreamer.
+AntiFEScriptCrash = 1                    ; Adds memory checks for FE::Object::SetScript.
+DisableAchievements = 1                  ; Disables the integrated achievement system that is unused in the PC version. Potentially increases game stability. (v1.1 and newer only)
+DisableBoosterPackThanks = 1             ; Skips the booster pack / DLC thanks screen on new profiles (v1.1 and newer only)
+DisablePunkBuster = 1                    ; Disables PunkBuster anti-cheat. Potentially increases game stability.
+DamageMemoryLeakFix = 1                  ; Fixes a memory leak in damage memory pools. Increases stability during a long play session, but also slightly increases memory requirements per-race until you exit the hub.
+Win11LANFix = 1                          ; Fixes LAN mode for people using Windows 11 and newer. (v1.1 and newer only)
 
 [MAIN]
-FixAspectRatio = 1                       // Corrects the width of the HUD, FOV, and FMVs.
-Scaling = 1                              // Adjusts FOV aspect ratio. Requires FixAspectRatio to be enabled. (0 = Original | 1 = Xbox 360 | 2 = Mathematically Correct)
-FMVWidescreenMode = 1                    // FMVs will appear in fullscreen. Requires FixAspectRatio to be enabled.
-ConsoleHUDSize = 0                       // Makes the HUD smaller like the console version.
+FixAspectRatio = 1                       ; Corrects the width of the HUD, FOV, and FMVs.
+Scaling = 1                              ; Adjusts FOV aspect ratio. Requires FixAspectRatio to be enabled. (0 = Original | 1 = Xbox 360 | 2 = Mathematically Correct)
+FMVWidescreenMode = 1                    ; FMVs will appear in fullscreen. Requires FixAspectRatio to be enabled.
+ConsoleHUDSize = 0                       ; Makes the HUD smaller like the console version.
 
 [MISC]
-SkipIntro = 0                            // Skips FMVs that play when you launch the game.
-SkipFEBootflow = 0                       // Skips the entire bootflow process and goes straight to the main menu. WARNING: You cannot load your alias if this is enabled!
-WindowedMode = 0                         // Enables windowed mode. (1 = Borderless | 2 = Border | 3 = Resizable Border | 4 = Borderless Fullscreen | 5 = Borderless Fullscreen Stretched)
-CustomUserFilesDirectoryInGameDir = 0    // User files will be stored in a specified directory (for example: "save"). Use '0' to disable.
-WriteSettingsToFile = 0                  // All registry settings will be saved to "settings.ini" in your profile folder. You must input your CD key and langauge in "settings.ini" when this option is enabled.
-ImproveGamepadSupport = 0                // Replaces keyboard icons with gamepad icons and assigns front-end actions. Requires an XInput gamepad. (1 = Xbox Icons | 2 = PlayStation Icons | 3 = None)
-LeftStickDeadzone = 10.0                 // Controls the deadzone of the left analog stick.
-BrakeLightFix = 1                        // Solves an issue that caused brake lights to only work when ABS was active.
-GammaFix = 1                             // Solves an issue that caused the wrong brightness value to be used on launch.
-ShadowRes = 2048                         // Controls the resolution of dynamic shadows. (2048 = Original) 
-DisableMotionBlur = 0                    // Disables motion blur without affecting the World FX setting.
-FixXenonEffects = 1                      // Fixes the alpha blending state of sparks. Disable this if you want to modify the texture properties.
-SimRate = -1                             // Controls the refresh rate of the gameplay engine. Match your monitor's refresh rate or your target frame rate. (0 = Disabled | -1 = Monitor Refresh Rate | -2 = Double Monitor Refresh Rate)
+SkipIntro = 0                            ; Skips FMVs that play when you launch the game.
+SkipFEBootflow = 0                       ; Skips the entire bootflow process and goes straight to the main menu. WARNING: You cannot load your alias if this is enabled!
+WindowedMode = 0                         ; Enables windowed mode. (1 = Borderless | 2 = Border | 3 = Resizable Border | 4 = Borderless Fullscreen | 5 = Borderless Fullscreen Stretched)
+CustomUserFilesDirectoryInGameDir = 0    ; User files will be stored in a specified directory (for example: "save"). Use '0' to disable.
+WriteSettingsToFile = 0                  ; All registry settings will be saved to "settings.ini" in your profile folder. You must input your CD key and langauge in "settings.ini" when this option is enabled.
+ImproveGamepadSupport = 0                ; Replaces keyboard icons with gamepad icons and assigns front-end actions. Requires an XInput gamepad. (1 = Xbox Icons | 2 = PlayStation Icons | 3 = None)
+LeftStickDeadzone = 10.0                 ; Controls the deadzone of the left analog stick.
+BrakeLightFix = 1                        ; Solves an issue that caused brake lights to only work when ABS was active.
+GammaFix = 1                             ; Solves an issue that caused the wrong brightness value to be used on launch.
+ShadowRes = 2048                         ; Controls the resolution of dynamic shadows. (2048 = Original) 
+DisableMotionBlur = 0                    ; Disables motion blur without affecting the World FX setting.
+FixXenonEffects = 1                      ; Fixes the alpha blending state of sparks. Disable this if you want to modify the texture properties.
+SimRate = -1                             ; Controls the refresh rate of the gameplay engine. Match your monitor's refresh rate or your target frame rate. (0 = Disabled | -1 = Monitor Refresh Rate | -2 = Double Monitor Refresh Rate)

--- a/data/NFSUndercover.GenericFix/scripts/NFSUndercover.GenericFix.ini
+++ b/data/NFSUndercover.GenericFix/scripts/NFSUndercover.GenericFix.ini
@@ -1,26 +1,26 @@
 [MultiFix]
-ResDetect = 1                            // Adds resolution auto-detection for the in-game options menu.
+ResDetect = 1                            ; Adds resolution auto-detection for the in-game options menu.
 
 [MAIN]
-Scaling = 0                              // Adjusts FOV aspect ratio to be mathematically correct. Requires FixFOV to be enabled.
+Scaling = 0                              ; Adjusts FOV aspect ratio to be mathematically correct. Requires FixFOV to be enabled.
 
 [MISC]
-SkipIntro = 0                            // Skips FMVs that play when you launch the game.
-WindowedMode = 0                         // Enables windowed mode. (1 = Borderless | 2 = Border | 3 = Resizable Border | 4 = Borderless Fullscreen | 5 = Borderless Fullscreen Stretched)
-CustomUserFilesDirectoryInGameDir = 0    // User files will be stored in a specified directory (for example: "save"). Use '0' to disable.
-WriteSettingsToFile = 0                  // All registry settings will be saved to "settings.ini" in your profile folder. You must input your CD key and langauge in "settings.ini" when this option is enabled.
-ImproveGamepadSupport = 0                // Replaces keyboard icons with gamepad icons and assigns front-end actions. Requires an XInput gamepad. (1 = Xbox Icons | 2 = PlayStation Icons | 3 = None)
-LeftStickDeadzone = 10.0                 // Controls the deadzone of the left analog stick.
+SkipIntro = 0                            ; Skips FMVs that play when you launch the game.
+WindowedMode = 0                         ; Enables windowed mode. (1 = Borderless | 2 = Border | 3 = Resizable Border | 4 = Borderless Fullscreen | 5 = Borderless Fullscreen Stretched)
+CustomUserFilesDirectoryInGameDir = 0    ; User files will be stored in a specified directory (for example: "save"). Use '0' to disable.
+WriteSettingsToFile = 0                  ; All registry settings will be saved to "settings.ini" in your profile folder. You must input your CD key and langauge in "settings.ini" when this option is enabled.
+ImproveGamepadSupport = 0                ; Replaces keyboard icons with gamepad icons and assigns front-end actions. Requires an XInput gamepad. (1 = Xbox Icons | 2 = PlayStation Icons | 3 = None)
+LeftStickDeadzone = 10.0                 ; Controls the deadzone of the left analog stick.
 
 [GRAPHICS]
-BloomIntensity = 1.0                     // Default (1.0): https://i.imgur.com/pQYfBzA.jpg | Disabled (0.0): https://i.imgur.com/A4MKLyS.jpg
-ShadowsRes = 8192                        // Controls the resolution of dynamic shadows. (8192 = Default | 1024 = Original | 16384 = Max)
-CSMScale = 1.0                           // Overall scale of the cascade shadow map. Larger the number, the greater the draw distance, but the lower the quality. (1.0 = Default)
-CSMScaleNear = 100.0                     // Nearest cascade (100.0 = Default | 5.0 = Original)
-CSMScaleMid = 175.0                      // Mid cascade (175.0 = Default | 30.0 = Original)
-CSMScaleFar = 300.0                      // Far cascade (300.0 = Default | 170.0 = Original)
-ImproveSceneryLOD = 0                    // Increases visible scenery on screen. Increases visible scenery in the closest map section, but may cause flickering for the farther ones.
-DisablePreculler = 0                     // Disables precalculated culling.
-BruteforceCulling = 0                    // Forces the game to use bruteforced culling type instead of TreeCull. This can decrease culled scenery, but may increase flicker.
-SimRate = -1                             // Controls the refresh rate of the gameplay engine. Match your monitor's refresh rate or your target frame rate. (0 = Disabled | -1 = Monitor Refresh Rate | -2 = Double Monitor Refresh Rate)
-DisableMotionBlur = 0                    // Disables motion blur without affecting the World FX setting.
+BloomIntensity = 1.0                     ; Default (1.0): https://i.imgur.com/pQYfBzA.jpg | Disabled (0.0): https://i.imgur.com/A4MKLyS.jpg
+ShadowsRes = 8192                        ; Controls the resolution of dynamic shadows. (8192 = Default | 1024 = Original | 16384 = Max)
+CSMScale = 1.0                           ; Overall scale of the cascade shadow map. Larger the number, the greater the draw distance, but the lower the quality. (1.0 = Default)
+CSMScaleNear = 100.0                     ; Nearest cascade (100.0 = Default | 5.0 = Original)
+CSMScaleMid = 175.0                      ; Mid cascade (175.0 = Default | 30.0 = Original)
+CSMScaleFar = 300.0                      ; Far cascade (300.0 = Default | 170.0 = Original)
+ImproveSceneryLOD = 0                    ; Increases visible scenery on screen. Increases visible scenery in the closest map section, but may cause flickering for the farther ones.
+DisablePreculler = 0                     ; Disables precalculated culling.
+BruteforceCulling = 0                    ; Forces the game to use bruteforced culling type instead of TreeCull. This can decrease culled scenery, but may increase flicker.
+SimRate = -1                             ; Controls the refresh rate of the gameplay engine. Match your monitor's refresh rate or your target frame rate. (0 = Disabled | -1 = Monitor Refresh Rate | -2 = Double Monitor Refresh Rate)
+DisableMotionBlur = 0                    ; Disables motion blur without affecting the World FX setting.

--- a/data/NFSUnderground.WidescreenFix/scripts/NFSUnderground.WidescreenFix.ini
+++ b/data/NFSUnderground.WidescreenFix/scripts/NFSUnderground.WidescreenFix.ini
@@ -1,18 +1,18 @@
 [MAIN]
-ResX = 0                                 // Use this option to control the horizontal resolution.
-ResY = 0                                 // Use this option to control the vertical resolution.
-FixHUD = 1                               // Corrects HUD aspect ratio.
-FixFOV = 1                               // Corrects FOV aspect ratio.
-Scaling = 0                              // Adjusts FOV aspect ratio to be mathematically correct. Requires FixFOV to be enabled.
-HUDWidescreenMode = 1                    // Moves HUD to the edge of the screen. Change offset in "NFSUnderground.WidescreenFix.dat" file for other aspect ratios.
-FMVWidescreenMode = 1                    // FMVs will appear in fullscreen for 16:9. (1 = Cropped | 2 = Stretched)
+ResX = 0                                 ; Use this option to control the horizontal resolution.
+ResY = 0                                 ; Use this option to control the vertical resolution.
+FixHUD = 1                               ; Corrects HUD aspect ratio.
+FixFOV = 1                               ; Corrects FOV aspect ratio.
+Scaling = 0                              ; Adjusts FOV aspect ratio to be mathematically correct. Requires FixFOV to be enabled.
+HUDWidescreenMode = 1                    ; Moves HUD to the edge of the screen. Change offset in "NFSUnderground.WidescreenFix.dat" file for other aspect ratios.
+FMVWidescreenMode = 1                    ; FMVs will appear in fullscreen for 16:9. (1 = Cropped | 2 = Stretched)
 
 [MISC]
-SkipIntro = 0                            // Skips FMVs that play when you launch the game.
-WindowedMode = 0                         // Enables windowed mode. (1 = Borderless | 2 = Border | 3 = Resizable Border | 4 = Borderless Fullscreen | 5 = Borderless Fullscreen Stretched)
-HideDebugObjects = 1                     // Hides debug objects. (1 = Remove Objects | 2 = Hide Objects with Pillarboxing)
-CustomUserFilesDirectoryInGameDir = 0    // User files will be stored in a specified directory (for example: "save"). Use '0' to disable.
-ImproveGamepadSupport = 0                // Replaces keyboard icons with gamepad icons and assigns front-end actions. Requires an XInput gamepad. (1 = Xbox Icons | 2 = PlayStation Icons | 3 = None)
-LeftStickDeadzone = 10.0                 // Controls the deadzone of the left analog stick.
-FPSLimit = -1                            // Allows users to control the frame rate limit. (0 = Disabled | -1 = Monitor Refresh Rate | -2 = Double Monitor Refresh Rate)
-BlackMagazineFix = 0                     // Fixes black background in magazine covers. May not be compatible with all versions of the game.
+SkipIntro = 0                            ; Skips FMVs that play when you launch the game.
+WindowedMode = 0                         ; Enables windowed mode. (1 = Borderless | 2 = Border | 3 = Resizable Border | 4 = Borderless Fullscreen | 5 = Borderless Fullscreen Stretched)
+HideDebugObjects = 1                     ; Hides debug objects. (1 = Remove Objects | 2 = Hide Objects with Pillarboxing)
+CustomUserFilesDirectoryInGameDir = 0    ; User files will be stored in a specified directory (for example: "save"). Use '0' to disable.
+ImproveGamepadSupport = 0                ; Replaces keyboard icons with gamepad icons and assigns front-end actions. Requires an XInput gamepad. (1 = Xbox Icons | 2 = PlayStation Icons | 3 = None)
+LeftStickDeadzone = 10.0                 ; Controls the deadzone of the left analog stick.
+FPSLimit = -1                            ; Allows users to control the frame rate limit. (0 = Disabled | -1 = Monitor Refresh Rate | -2 = Double Monitor Refresh Rate)
+BlackMagazineFix = 0                     ; Fixes black background in magazine covers. May not be compatible with all versions of the game.

--- a/data/NFSUnderground2.WidescreenFix/scripts/NFSUnderground2.WidescreenFix.ini
+++ b/data/NFSUnderground2.WidescreenFix/scripts/NFSUnderground2.WidescreenFix.ini
@@ -1,24 +1,24 @@
 [MAIN]
-ResX = 0                                 // Use this option to control the horizontal resolution.
-ResY = 0                                 // Use this option to control the vertical resolution.
-FixHUD = 1                               // Corrects HUD aspect ratio.
-FixFOV = 1                               // Corrects FOV aspect ratio.
-Scaling = 0                              // Adjusts FOV aspect ratio to be mathematically correct. Requires FixFOV to be enabled.
-HUDWidescreenMode = 1                    // Moves HUD to the edge of the screen. Change offset in "NFSUnderground2.WidescreenFix.dat" file for other aspect ratios.
-FMVWidescreenMode = 1                    // FMVs will appear in fullscreen for 16:9. (1 = Cropped | 2 = Stretched)
+ResX = 0                                 ; Use this option to control the horizontal resolution.
+ResY = 0                                 ; Use this option to control the vertical resolution.
+FixHUD = 1                               ; Corrects HUD aspect ratio.
+FixFOV = 1                               ; Corrects FOV aspect ratio.
+Scaling = 0                              ; Adjusts FOV aspect ratio to be mathematically correct. Requires FixFOV to be enabled.
+HUDWidescreenMode = 1                    ; Moves HUD to the edge of the screen. Change offset in "NFSUnderground2.WidescreenFix.dat" file for other aspect ratios.
+FMVWidescreenMode = 1                    ; FMVs will appear in fullscreen for 16:9. (1 = Cropped | 2 = Stretched)
 
 [MISC]
-SkipIntro = 0                            // Skips FMVs that play when you launch the game.
-WindowedMode = 0                         // Enables windowed mode. (1 = Borderless | 2 = Border | 3 = Resizable Border | 4 = Borderless Fullscreen | 5 = Borderless Fullscreen Stretched)
-DisableCutsceneBorders = 1               // Removes letterboxing that appears during cutscenes.
-CustomUserFilesDirectoryInGameDir = 0    // User files will be stored in a specified directory (for example: "save"). Use '0' to disable.
-WriteSettingsToFile = 0                  // All registry settings will be saved to "settings.ini" in your profile folder. You must input your CD key and langauge in "settings.ini" when this option is enabled.
-ImproveGamepadSupport = 0                // Adds text to buttons and assigns front-end actions. Requires an XInput gamepad. (1 = Xbox Text | 2 = PlayStation Text | 3 = PC Text | 4 = None)
-LeftStickDeadzone = 10.0                 // Controls the deadzone of the left analog stick.
-FPSLimit = -1                            // Allows users to control the frame rate limit. (0 = Disabled | -1 = Monitor Refresh Rate | -2 = Double Monitor Refresh Rate)
-HighFPSCutscenes = 1                     // Increases the frame rate limit for cutscenes to the nearest multiple of 30 (maximum is currently 60 due to bugs)
-SingleCoreAffinity = 1                   // Limits game to one CPU core to prevent crashing.
+SkipIntro = 0                            ; Skips FMVs that play when you launch the game.
+WindowedMode = 0                         ; Enables windowed mode. (1 = Borderless | 2 = Border | 3 = Resizable Border | 4 = Borderless Fullscreen | 5 = Borderless Fullscreen Stretched)
+DisableCutsceneBorders = 1               ; Removes letterboxing that appears during cutscenes.
+CustomUserFilesDirectoryInGameDir = 0    ; User files will be stored in a specified directory (for example: "save"). Use '0' to disable.
+WriteSettingsToFile = 0                  ; All registry settings will be saved to "settings.ini" in your profile folder. You must input your CD key and langauge in "settings.ini" when this option is enabled.
+ImproveGamepadSupport = 0                ; Adds text to buttons and assigns front-end actions. Requires an XInput gamepad. (1 = Xbox Text | 2 = PlayStation Text | 3 = PC Text | 4 = None)
+LeftStickDeadzone = 10.0                 ; Controls the deadzone of the left analog stick.
+FPSLimit = -1                            ; Allows users to control the frame rate limit. (0 = Disabled | -1 = Monitor Refresh Rate | -2 = Double Monitor Refresh Rate)
+HighFPSCutscenes = 1                     ; Increases the frame rate limit for cutscenes to the nearest multiple of 30 (maximum is currently 60 due to bugs)
+SingleCoreAffinity = 1                   ; Limits game to one CPU core to prevent crashing.
 
 [NOSTrail]
-FixNOSTrailLength = 1                    // Fixes the NOS trail length for higher FPS.
-CustomNOSTrailLength = 1.0               // Adjusts the total distance of the NOS trail. You may need to adjust this if you're playing at very high FPS (240+). The higher the SimRate & FPS difference, the longer the trail.
+FixNOSTrailLength = 1                    ; Fixes the NOS trail length for higher FPS.
+CustomNOSTrailLength = 1.0               ; Adjusts the total distance of the NOS trail. You may need to adjust this if you're playing at very high FPS (240+). The higher the SimRate & FPS difference, the longer the trail.


### PR DESCRIPTION
Replaces all double-slashes with semicolons, which is the correct way to comment in the .ini format!