### PR TITLE
[NFSMW] implement unused graphics settings + ini reformat

### DIFF
--- a/data/NFSMostWanted.WidescreenFix/scripts/NFSMostWanted.WidescreenFix.ini
+++ b/data/NFSMostWanted.WidescreenFix/scripts/NFSMostWanted.WidescreenFix.ini
@@ -23,6 +23,10 @@ ForceHighSpecAudio = 1                   ; Enables 44100Hz sample rate audio reg
 DisableMotionBlur = 0                    ; Allows users to disable motion blur without changing registry settings.
 SimRate = -1                             ; Controls the refresh rate of the gameplay engine. Match your monitor's refresh rate or your target frame rate. (0 = Disabled | -1 = Monitor Refresh Rate | -2 = Double Monitor Refresh Rate)
 
+[GRAPHICS]
+LightStreaksEnable = 0                   ; Leftover from NFS Underground 2. Enables the light trail effect. Not very visible at higher FPS than 60.
+BleachByPassEnable = 0                   ; Leftover from NFS Underground 2. Enables the "Enhanced Contrast" effect. Requires the IDI_SCREENFILTER_FX from Underground 2 to work.
+
 [NOSTrail]
 FixNOSTrailLength = 1                    ; Fixes the NOS trail length for higher FPS.
 CustomNOSTrailLength = 1.0               ; Adjusts the total distance of the NOS trail. You may need to adjust this if you're playing at very high FPS (240+). The higher the SimRate & FPS difference, the longer the trail.

--- a/data/NFSMostWanted.WidescreenFix/scripts/NFSMostWanted.WidescreenFix.ini
+++ b/data/NFSMostWanted.WidescreenFix/scripts/NFSMostWanted.WidescreenFix.ini
@@ -24,8 +24,8 @@ DisableMotionBlur = 0                    ; Allows users to disable motion blur w
 SimRate = -1                             ; Controls the refresh rate of the gameplay engine. Match your monitor's refresh rate or your target frame rate. (0 = Disabled | -1 = Monitor Refresh Rate | -2 = Double Monitor Refresh Rate)
 
 [GRAPHICS]
-LightStreaksEnable = 0                   ; Leftover from NFS Underground 2. Enables the light trail effect. Not very visible at higher FPS than 60.
-BleachByPassEnable = 0                   ; Leftover from NFS Underground 2. Enables the "Enhanced Contrast" effect. Requires the IDI_SCREENFILTER_FX from Underground 2 to work.
+LightStreaksEnable = 0                   ; Leftover from NFS Underground 2. Enables the light trail effect. Not very visible at higher FPS than 60, but it does make the flares more saturated in color.
+BleachByPassEnable = 0                   ; (EXPERIMENTAL) Leftover from NFS Underground 2. Enables the "Enhanced Contrast" effect. Requires the IDI_SCREENFILTER_FX shader from Underground 2 to work. If you do not have it, the screen will be blurry!
 
 [NOSTrail]
 FixNOSTrailLength = 1                    ; Fixes the NOS trail length for higher FPS.

--- a/data/NFSMostWanted.WidescreenFix/scripts/NFSMostWanted.WidescreenFix.ini
+++ b/data/NFSMostWanted.WidescreenFix/scripts/NFSMostWanted.WidescreenFix.ini
@@ -10,20 +10,20 @@ FMVWidescreenMode = 1                    ; FMVs will appear in fullscreen for 16
 [MISC]
 SkipIntro = 0                            ; Skips FMVs that play when you launch the game.
 WindowedMode = 0                         ; Enables windowed mode. (1 = Borderless | 2 = Border | 3 = Resizable Border | 4 = Borderless Fullscreen | 5 = Borderless Fullscreen Stretched)
-ShadowsRes = 2048                        ; Controls the resolution of dynamic shadows and enables them for Intel GPUs. (1024 = Original | 2048 = Xbox 360 | 16384 = Max)
-AutoScaleShadowsRes = 1                  ; Adjusts the specified ShadowsRes based on the user's aspect ratio to maintain quality. This may negatively affect performance.
-DisableShadowTextureFilterOnRadeon = 1   ; Disables the forced bilinear filter for the shadow texture on ATI/AMD Radeon GPUs.
-ShadowsFix = 1                           ; Dynamic shadows will no longer disappear when going into tunnels, under bridges, etc.
-ImproveShadowLOD = 1                     ; Increases the level of detail of dynamic shadows. This may negatively affect performance.
 CustomUserFilesDirectoryInGameDir = 0    ; User files will be stored in a specified directory (for example: "save"). Use '0' to disable.
 WriteSettingsToFile = 0                  ; All registry settings will be saved to "settings.ini" in your profile folder. You must input your CD key and langauge in "settings.ini" when this option is enabled.
 ImproveGamepadSupport = 0                ; Replaces keyboard icons with gamepad icons and assigns front-end actions. Requires an XInput gamepad. (1 = Xbox Icons | 2 = PlayStation Icons | 3 = None)
 LeftStickDeadzone = 10.0                 ; Controls the deadzone of the left analog stick.
 ForceHighSpecAudio = 1                   ; Enables 44100Hz sample rate audio regardless of registry settings.
-DisableMotionBlur = 0                    ; Allows users to disable motion blur without changing registry settings.
 SimRate = -1                             ; Controls the refresh rate of the gameplay engine. Match your monitor's refresh rate or your target frame rate. (0 = Disabled | -1 = Monitor Refresh Rate | -2 = Double Monitor Refresh Rate)
 
 [GRAPHICS]
+ShadowsRes = 2048                        ; Controls the resolution of dynamic shadows and enables them for Intel GPUs. (1024 = Original | 2048 = Xbox 360 | 16384 = Max)
+ShadowsFix = 1                           ; Dynamic shadows will no longer disappear when going into tunnels, under bridges, etc.
+ImproveShadowLOD = 1                     ; Increases the level of detail of dynamic shadows. This may negatively affect performance.
+AutoScaleShadowsRes = 1                  ; Adjusts the specified ShadowsRes based on the user's aspect ratio to maintain quality. This may negatively affect performance.
+DisableShadowTextureFilterOnRadeon = 1   ; Disables the forced bilinear filter for the shadow texture on ATI/AMD Radeon GPUs.
+DisableMotionBlur = 0                    ; Allows users to disable motion blur without changing registry settings.
 LightStreaksEnable = 0                   ; Leftover from NFS Underground 2. Enables the light trail effect. Not very visible at higher FPS than 60, but it does make the flares more saturated in color.
 BleachByPassEnable = 0                   ; (EXPERIMENTAL) Leftover from NFS Underground 2. Enables the "Enhanced Contrast" effect. Requires the IDI_SCREENFILTER_FX shader from Underground 2 to work. If you do not have it, the screen will be blurry!
 

--- a/source/NFSMostWanted.WidescreenFix/dllmain.cpp
+++ b/source/NFSMostWanted.WidescreenFix/dllmain.cpp
@@ -266,15 +266,10 @@ void Init()
     int nFMVWidescreenMode = iniReader.ReadInteger("MAIN", "FMVWidescreenMode", 1);
     nScaling = iniReader.ReadInteger("MAIN", "Scaling", 1);
     bool bSkipIntro = iniReader.ReadInteger("MISC", "SkipIntro", 0) != 0;
-    ShadowRes::Resolution = iniReader.ReadInteger("MISC", "ShadowsRes", 2048);
-    ShadowRes::bAutoScaleShadowsRes = iniReader.ReadInteger("MISC", "AutoScaleShadowsRes", 1) != 0;
-    ShadowRes::bDisableShadowTextureFilterOnRadeon = iniReader.ReadInteger("MISC", "DisableShadowTextureFilterOnRadeon", 1) != 0;
-    bool bShadowsFix = iniReader.ReadInteger("MISC", "ShadowsFix", 1) != 0;
-    bool bImproveShadowLOD = iniReader.ReadInteger("MISC", "ImproveShadowLOD", 1) != 0;
+
     static auto szCustomUserFilesDirectoryInGameDir = iniReader.ReadString("MISC", "CustomUserFilesDirectoryInGameDir", "");
     bool bWriteSettingsToFile = iniReader.ReadInteger("MISC", "WriteSettingsToFile", 1) != 0;
     static int nImproveGamepadSupport = iniReader.ReadInteger("MISC", "ImproveGamepadSupport", 0);
-    bool bDisableMotionBlur = iniReader.ReadInteger("MISC", "DisableMotionBlur", 0) != 0;
     bool bForceHighSpecAudio = iniReader.ReadInteger("MISC", "ForceHighSpecAudio", 1) != 0;
     static float fLeftStickDeadzone = iniReader.ReadFloat("MISC", "LeftStickDeadzone", 10.0f);
     static float fRainDropletsScale = iniReader.ReadFloat("MISC", "RainDropletsScale", 0.5f);
@@ -283,6 +278,12 @@ void Init()
         szCustomUserFilesDirectoryInGameDir.clear();
     int nWindowedMode = iniReader.ReadInteger("MISC", "WindowedMode", 0);
 
+    ShadowRes::Resolution = iniReader.ReadInteger("GRAPHICS", "ShadowsRes", 2048);
+    ShadowRes::bAutoScaleShadowsRes = iniReader.ReadInteger("GRAPHICS", "AutoScaleShadowsRes", 1) != 0;
+    ShadowRes::bDisableShadowTextureFilterOnRadeon = iniReader.ReadInteger("GRAPHICS", "DisableShadowTextureFilterOnRadeon", 1) != 0;
+    bool bShadowsFix = iniReader.ReadInteger("GRAPHICS", "ShadowsFix", 1) != 0;
+    bool bImproveShadowLOD = iniReader.ReadInteger("GRAPHICS", "ImproveShadowLOD", 1) != 0;
+    bool bDisableMotionBlur = iniReader.ReadInteger("GRAPHICS", "DisableMotionBlur", 0) != 0;
     bool bLightStreaksEnable = iniReader.ReadInteger("GRAPHICS", "LightStreaksEnable", 0) != 0;
     bool bBleachByPassEnable = iniReader.ReadInteger("GRAPHICS", "BleachByPassEnable", 0) != 0;
 

--- a/source/NFSMostWanted.WidescreenFix/dllmain.cpp
+++ b/source/NFSMostWanted.WidescreenFix/dllmain.cpp
@@ -1097,6 +1097,25 @@ void Init()
         *(uint32_t*)g_LightStreaksEnable = 1;
     }
 
+    if (bBleachByPassEnable)
+    {
+        uintptr_t loc_6C18D1 = reinterpret_cast<uintptr_t>(hook::pattern("A1 ? ? ? ? 8B 0C 85 ? ? ? ? 85 C9 75 20 85 C0").get_first(0)) - 0x83;
+        uintptr_t loc_6C1A9F = reinterpret_cast<uintptr_t>(hook::pattern("C7 44 24 10 40 00 00 00 FF 15 ? ? ? ? 39 7C 24 18").get_first(0)) - 0x81;
+        uintptr_t loc_6C1B0E = loc_6C1A9F + 0x6F;
+        uintptr_t loc_6C2FC0 = reinterpret_cast<uintptr_t>(hook::pattern("99 83 E2 03 03 C2 8B C8 8B C7 99 83 E2 03 03 C2 C1 F8 02 A3").get_first(0)) - 0x16B;
+
+
+        uintptr_t g_BleachByPassEnable = *reinterpret_cast<uintptr_t*>(loc_6C18D1 + 1);
+
+        // disable control of the variable
+        injector::MakeNOP(loc_6C18D1, 5);
+        injector::MakeNOP(loc_6C1A9F, 6);
+        injector::MakeNOP(loc_6C1B0E, 6);
+        injector::MakeNOP(loc_6C2FC0, 6);
+
+        *(uint32_t*)g_BleachByPassEnable = 1;
+    }
+
     if (bWriteSettingsToFile)
     {
         char szSettingsSavePath[MAX_PATH];

--- a/source/NFSMostWanted.WidescreenFix/dllmain.cpp
+++ b/source/NFSMostWanted.WidescreenFix/dllmain.cpp
@@ -282,6 +282,10 @@ void Init()
     if (szCustomUserFilesDirectoryInGameDir.empty() || szCustomUserFilesDirectoryInGameDir == "0")
         szCustomUserFilesDirectoryInGameDir.clear();
     int nWindowedMode = iniReader.ReadInteger("MISC", "WindowedMode", 0);
+
+    bool bLightStreaksEnable = iniReader.ReadInteger("GRAPHICS", "LightStreaksEnable", 0) != 0;
+    bool bBleachByPassEnable = iniReader.ReadInteger("GRAPHICS", "BleachByPassEnable", 0) != 0;
+
     bool bFixNOSTrailLength = iniReader.ReadInteger("NOSTrail", "FixNOSTrailLength", 1) == 1;
     bool bFixNOSTrailPosition = iniReader.ReadInteger("NOSTrail", "FixNOSTrailPosition", 0) != 0;
     static float fCustomNOSTrailLength = iniReader.ReadFloat("NOSTrail", "CustomNOSTrailLength", 1.0f);
@@ -1073,6 +1077,24 @@ void Init()
             pattern = hook::pattern("55 8B EC 83 E4 F0 83 EC 74 53 56 57 8B F9 89 7C 24 3C"); // 0x00742950
             CarRenderInfo_RenderFlaresOnCar = (void(__thiscall*)(void*, void*, bVector3*, bMatrix4*, int, int, int))pattern.get_first(0);
         }
+    }
+
+    if (bLightStreaksEnable)
+    {
+        uintptr_t loc_6C1841 = reinterpret_cast<uintptr_t>(hook::pattern("A1 ? ? ? ? 8B 0C 85 ? ? ? ? 85 C9 75 20 85 C0").get_first(0)) - 0x113;
+        uintptr_t loc_6C19EC = reinterpret_cast<uintptr_t>(hook::pattern("C7 44 24 10 40 00 00 00 FF 15 ? ? ? ? 39 7C 24 18").get_first(0)) - 0x134;
+        uintptr_t loc_6C1AD8 = loc_6C19EC + 0xEC;
+        uintptr_t loc_6C310B = reinterpret_cast<uintptr_t>(hook::pattern("99 83 E2 03 03 C2 8B C8 8B C7 99 83 E2 03 03 C2 C1 F8 02 A3").get_first(0)) - 0x20;
+
+        uintptr_t g_LightStreaksEnable = *reinterpret_cast<uintptr_t*>(loc_6C1841 + 1);
+
+        // disable control of the variable
+        injector::MakeNOP(loc_6C1841, 5);
+        injector::MakeNOP(loc_6C19EC, 6);
+        injector::MakeNOP(loc_6C1AD8, 6);
+        injector::MakeNOP(loc_6C310B, 6);
+
+        *(uint32_t*)g_LightStreaksEnable = 1;
     }
 
     if (bWriteSettingsToFile)

--- a/source/NFSMostWanted.WidescreenFix/dllmain.cpp
+++ b/source/NFSMostWanted.WidescreenFix/dllmain.cpp
@@ -1104,7 +1104,6 @@ void Init()
         uintptr_t loc_6C1B0E = loc_6C1A9F + 0x6F;
         uintptr_t loc_6C2FC0 = reinterpret_cast<uintptr_t>(hook::pattern("99 83 E2 03 03 C2 8B C8 8B C7 99 83 E2 03 03 C2 C1 F8 02 A3").get_first(0)) - 0x16B;
 
-
         uintptr_t g_BleachByPassEnable = *reinterpret_cast<uintptr_t*>(loc_6C18D1 + 1);
 
         // disable control of the variable


### PR DESCRIPTION
- Added a GRAPHICS section to the .ini to de-clutter the MISC section - THIS WILL BREAK BACKWARDS COMPATIBILITY WITH THE OLD INIs, users must update .ini in the next version
- Added option to control g_LightStreaksEnable
- Added option to control g_BleachByPassEnable