### PR TITLE
[NFSMW] add resolution text fix for the VO menu

### DIFF
--- a/data/NFSMostWanted.WidescreenFix/scripts/NFSMostWanted.WidescreenFix.ini
+++ b/data/NFSMostWanted.WidescreenFix/scripts/NFSMostWanted.WidescreenFix.ini
@@ -15,6 +15,7 @@ WriteSettingsToFile = 0                  ; All registry settings will be saved t
 ImproveGamepadSupport = 0                ; Replaces keyboard icons with gamepad icons and assigns front-end actions. Requires an XInput gamepad. (1 = Xbox Icons | 2 = PlayStation Icons | 3 = None)
 LeftStickDeadzone = 10.0                 ; Controls the deadzone of the left analog stick.
 ForceHighSpecAudio = 1                   ; Enables 44100Hz sample rate audio regardless of registry settings.
+FixResolutionText = 1                    ; Shows the current resolution in the Video Options menu.
 SimRate = -1                             ; Controls the refresh rate of the gameplay engine. Match your monitor's refresh rate or your target frame rate. (0 = Disabled | -1 = Monitor Refresh Rate | -2 = Double Monitor Refresh Rate)
 
 [GRAPHICS]


### PR DESCRIPTION
I think it's about time this was fixed.

I'll consider making it functional later.

Oh and it works in resizable windows too, so when you resize the window and re-enter the menu it actually shows the current window size.

![image](https://github.com/ThirteenAG/WidescreenFixesPack/assets/8014093/322864ae-0a4e-4548-8c7d-284bad021526)
