### PR TITLE
[NFSC and older] clamp min res to 32x32

### DIFF
--- a/source/NFSCarbon.WidescreenFix/dllmain.cpp
+++ b/source/NFSCarbon.WidescreenFix/dllmain.cpp
@@ -262,6 +262,13 @@ void Init()
     if (!Screen.Width || !Screen.Height)
         std::tie(Screen.Width, Screen.Height) = GetDesktopRes();
 
+    // clamp the size because below 32x32 the game crashes!
+    if (Screen.Width < 32)
+        Screen.Width = 32;
+
+    if (Screen.Height < 32)
+        Screen.Height = 32;
+
     Screen.fWidth = static_cast<float>(Screen.Width);
     Screen.fHeight = static_cast<float>(Screen.Height);
     Screen.fAspectRatio = (Screen.fWidth / Screen.fHeight);

--- a/source/NFSMostWanted.WidescreenFix/dllmain.cpp
+++ b/source/NFSMostWanted.WidescreenFix/dllmain.cpp
@@ -112,6 +112,14 @@ void updateValues(const float& newWidth, const float& newHeight)
     //Screen resolution
     Screen.Width = newWidth;
     Screen.Height = newHeight;
+
+    // clamp the size because below 32x32 the game crashes!
+    if (Screen.Width < 32)
+        Screen.Width = 32;
+
+    if (Screen.Height < 32)
+        Screen.Height = 32;
+
     Screen.fWidth = static_cast<float>(Screen.Width);
     Screen.fHeight = static_cast<float>(Screen.Height);
     Screen.fAspectRatio = (Screen.fWidth / Screen.fHeight);
@@ -295,6 +303,13 @@ void Init()
 
     if (!Screen.Width || !Screen.Height)
         std::tie(Screen.Width, Screen.Height) = GetDesktopRes();
+
+    // clamp the size because below 32x32 the game crashes!
+    if (Screen.Width < 32)
+        Screen.Width = 32;
+
+    if (Screen.Height < 32)
+        Screen.Height = 32;
 
     Screen.fWidth = static_cast<float>(Screen.Width);
     Screen.fHeight = static_cast<float>(Screen.Height);

--- a/source/NFSUnderground.WidescreenFix/dllmain.cpp
+++ b/source/NFSUnderground.WidescreenFix/dllmain.cpp
@@ -323,6 +323,13 @@ void Init()
     if (!Screen.nWidth || !Screen.nHeight)
         std::tie(Screen.nWidth, Screen.nHeight) = GetDesktopRes();
 
+    // clamp the size because below 32x32 the game crashes!
+    if (Screen.nWidth < 32)
+        Screen.nWidth = 32;
+
+    if (Screen.nHeight < 32)
+        Screen.nHeight = 32;
+
     Screen.fWidth = static_cast<float>(Screen.nWidth);
     Screen.fHeight = static_cast<float>(Screen.nHeight);
     Screen.nWidth43 = static_cast<uint32_t>(Screen.fHeight * (4.0f / 3.0f));

--- a/source/NFSUnderground2.WidescreenFix/dllmain.cpp
+++ b/source/NFSUnderground2.WidescreenFix/dllmain.cpp
@@ -123,6 +123,13 @@ void Init()
     if (!Screen.Width || !Screen.Height)
         std::tie(Screen.Width, Screen.Height) = GetDesktopRes();
 
+    // clamp the size because below 32x32 the game crashes!
+    if (Screen.Width < 32)
+        Screen.Width = 32;
+
+    if (Screen.Height < 32)
+        Screen.Height = 32;
+
     Screen.fWidth = static_cast<float>(Screen.Width);
     Screen.fHeight = static_cast<float>(Screen.Height);
     Screen.fAspectRatio = (Screen.fWidth / Screen.fHeight);


### PR DESCRIPTION
Here's the last one for today I hope - minimum resolution clamp for NFS games that have assignable resolutions.

This is to prevent any crashes from happening because you can't run the games in an extremely low res.