### PR TITLE
[NFSPS] remove ImproveGamepadSupport

### DIFF
--- a/data/NFSProStreet.GenericFix/scripts/NFSProStreet.GenericFix.ini
+++ b/data/NFSProStreet.GenericFix/scripts/NFSProStreet.GenericFix.ini
@@ -18,12 +18,14 @@ FMVWidescreenMode = 1                    ; FMVs will appear in fullscreen. Requi
 ConsoleHUDSize = 0                       ; Makes the HUD smaller like the console version.
 
 [MISC]
+; Looking for the ImproveGamepadSupport option?
+; The feature has been deprecated and replaced by NFS_XtendedInput.
+; Please use NFS_XtendedInput for NFS Pro Street instead: https://github.com/xan1242/NFS-XtendedInput/releases
 SkipIntro = 0                            ; Skips FMVs that play when you launch the game.
 SkipFEBootflow = 0                       ; Skips the entire bootflow process and goes straight to the main menu. WARNING: You cannot load your alias if this is enabled!
 WindowedMode = 0                         ; Enables windowed mode. (1 = Borderless | 2 = Border | 3 = Resizable Border | 4 = Borderless Fullscreen | 5 = Borderless Fullscreen Stretched)
 CustomUserFilesDirectoryInGameDir = 0    ; User files will be stored in a specified directory (for example: "save"). Use '0' to disable.
 WriteSettingsToFile = 0                  ; All registry settings will be saved to "settings.ini" in your profile folder. You must input your CD key and langauge in "settings.ini" when this option is enabled.
-ImproveGamepadSupport = 0                ; Replaces keyboard icons with gamepad icons and assigns front-end actions. Requires an XInput gamepad. (1 = Xbox Icons | 2 = PlayStation Icons | 3 = None)
 LeftStickDeadzone = 10.0                 ; Controls the deadzone of the left analog stick.
 BrakeLightFix = 1                        ; Solves an issue that caused brake lights to only work when ABS was active.
 GammaFix = 1                             ; Solves an issue that caused the wrong brightness value to be used on launch.


### PR DESCRIPTION
With the release of NFS_XtendedInput v1.18 I feel comfortable removing `ImproveGamepadSupport` for Pro Street.

I've ironed out most of the major bugs surrounding the configuration menu and restructured how the mappings work. Now, the controls are saved per user profile.

Link to the current version at the time of writing:
https://github.com/xan1242/NFS-XtendedInput/releases/tag/1.18

Please note that users will have to set up XInput to properly control the game. So if they have a non-XInput compliant controller, they will have to work around it (DS4Windows, Steam Input, X360CE, ScpServer, Steam Controller with Gyro, all of these were tested and working).

There are Win7 builds available. Everyone using WS/Generic Fix should avoid these unless they know what they're doing.

In case users have trouble with getting the game to recognize the controllers and/or it tells them that it's disconnected, they should try to enable `XInputOmniMode` in the config file. This is because sometimes the XInput port 1 ends up unassigned for some users in some edge cases due to incorrect XInput configuration.

If any more trouble arises, ping me. But it should be basically OK for most people. An older version of this was already deployed in Pepega Edition mod and most people had no problems (not counting a few exotic requests such as DS4 Gyro steering).

Other games are to come. The bare minimum would be to support the in-game remap menu for each game. I'll trickle them out and deprecate as I work on it.