### PR TITLE
[NFSPS] FE & FMV scaling rework

### DIFF
--- a/data/NFSProStreet.GenericFix/scripts/NFSProStreet.GenericFix.ini
+++ b/data/NFSProStreet.GenericFix/scripts/NFSProStreet.GenericFix.ini
@@ -16,6 +16,8 @@ FixAspectRatio = 1                       ; Corrects the width of the HUD, FOV, a
 Scaling = 1                              ; Adjusts FOV aspect ratio. Requires FixAspectRatio to be enabled. (0 = Original | 1 = Xbox 360 | 2 = Mathematically Correct)
 FMVWidescreenMode = 1                    ; FMVs will appear in fullscreen. Requires FixAspectRatio to be enabled.
 FEScale = 1.00                           ; Set the size of UI elements here. (Default = 1.00, Xbox 360 = 0.92)
+AutoFitFE = 1                            ; Automatically scales the UI contents to fully fit the width of the screen. Useful for aspect ratios such as 16:10.
+ForceFEMode = 0                          ; Forces the UI aspect ratio mode. (0 = Off (Default), 1 = Widescreen, 2 = Non-Widescreen)
 
 [MISC]
 ; Looking for the ImproveGamepadSupport option?

--- a/data/NFSProStreet.GenericFix/scripts/NFSProStreet.GenericFix.ini
+++ b/data/NFSProStreet.GenericFix/scripts/NFSProStreet.GenericFix.ini
@@ -15,7 +15,7 @@ Win11LANFix = 1                          ; Fixes LAN mode for people using Windo
 FixAspectRatio = 1                       ; Corrects the width of the HUD, FOV, and FMVs.
 Scaling = 1                              ; Adjusts FOV aspect ratio. Requires FixAspectRatio to be enabled. (0 = Original | 1 = Xbox 360 | 2 = Mathematically Correct)
 FMVWidescreenMode = 1                    ; FMVs will appear in fullscreen. Requires FixAspectRatio to be enabled.
-ConsoleHUDSize = 0                       ; Makes the HUD smaller like the console version.
+FEScale = 1.00                           ; Set the size of UI elements here. (Default = 1.00, Xbox 360 = 0.92)
 
 [MISC]
 ; Looking for the ImproveGamepadSupport option?

--- a/source/NFSProStreet.GenericFix/dllmain.cpp
+++ b/source/NFSProStreet.GenericFix/dllmain.cpp
@@ -635,7 +635,8 @@ void Init()
     bool bFixAspectRatio = iniReader.ReadInteger("MAIN", "FixAspectRatio", 1) != 0;
     static int32_t nScaling = iniReader.ReadInteger("MAIN", "Scaling", 1);
     bool bFMVWidescreenMode = iniReader.ReadInteger("MAIN", "FMVWidescreenMode", 1) != 0;
-    bool bConsoleHUDSize = iniReader.ReadInteger("MAIN", "ConsoleHUDSize", 0) != 0;
+    //bool bConsoleHUDSize = iniReader.ReadInteger("MAIN", "ConsoleHUDSize", 0) != 0;
+    static float FEScale = iniReader.ReadFloat("MAIN", "FEScale", 1.0f);
     bool bGammaFix = iniReader.ReadInteger("MISC", "GammaFix", 1) != 0;
     bool bSkipIntro = iniReader.ReadInteger("MISC", "SkipIntro", 0) != 0;
     bool bSkipFEBootflow = iniReader.ReadInteger("MISC", "SkipFEBootflow", 0) != 0;
@@ -858,12 +859,16 @@ void Init()
         }; injector::MakeInline<HUDWidescreenModeHook>(pattern.count(7).get(0).get<uint32_t>(0)); // 44C332
     }
 
-    if (bConsoleHUDSize)
+    uintptr_t loc_4B4518 = reinterpret_cast<uintptr_t>(hook::pattern("F3 0F 11 44 24 14 F3 0F 10 05 ? ? ? ? 6A 00").get_first(0)) + 6;
+    struct FEScaleHook
     {
-        static constexpr float HUDSize = 1.0875f;
-        uint32_t* dword_4B4455 = hook::pattern("F3 0F 10 ? ? ? ? ? 8B 3D ? ? ? ? C6 05 ? ? ? ? 00").count(1).get(0).get<uint32_t>(4);
-        injector::WriteMemory(dword_4B4455, &HUDSize, true);
-    }
+        void operator()(injector::reg_pack& regs)
+        {
+            *(float*)(regs.esp + 0x14) *= FEScale;
+            _asm movss xmm0, ds: [FEScale];
+
+        }
+    }; injector::MakeInline<FEScaleHook>(loc_4B4518, loc_4B4518 + 8);
 
     if (bGammaFix)
     {


### PR DESCRIPTION
- Added an option for FE auto fitting for widescreen aspects below 16:9 but above 1.5555:1
- Added an option to force FE mode (widescreen and standard)
- Added an option to control FE scaling and removed ConsoleHUDSize (now just set 0.92 for same effect)
- Added extra patches to the existing widescreen checks in the game code
- FMVs now scale together with the FE scale to fix mismatched flashers and subtitlers

I'm planning to do this same deal for MW and Carbon.