### PR TITLE
[NFSU/U2] implement FE scaling

### DIFF
--- a/data/NFSUnderground.WidescreenFix/scripts/NFSUnderground.WidescreenFix.ini
+++ b/data/NFSUnderground.WidescreenFix/scripts/NFSUnderground.WidescreenFix.ini
@@ -6,6 +6,10 @@ FixFOV = 1                               ; Corrects FOV aspect ratio.
 Scaling = 0                              ; Adjusts FOV aspect ratio to be mathematically correct. Requires FixFOV to be enabled.
 HUDWidescreenMode = 1                    ; Moves HUD to the edge of the screen. Change offset in "NFSUnderground.WidescreenFix.dat" file for other aspect ratios.
 FMVWidescreenMode = 1                    ; FMVs will appear in fullscreen for 16:9. (1 = Cropped | 2 = Stretched)
+FEScale = 1.00                           ; Set the size of UI elements here. (Default = 1.00, Xbox = 0.92)
+FMVScale = 1.00                          ; Set the size of FMVs here. (Default = 1.00)
+AutoFitFE = 0                            ; Automatically fits 16:9 UI content to smaller aspect ratios.
+AutoFitFMV = 1                           ; Automatically scales the FMVs to fully fit the width of the screen. This introduces black bars on aspect ratios smaller than 16:9.
 
 [MISC]
 SkipIntro = 0                            ; Skips FMVs that play when you launch the game.

--- a/data/NFSUnderground2.WidescreenFix/scripts/NFSUnderground2.WidescreenFix.ini
+++ b/data/NFSUnderground2.WidescreenFix/scripts/NFSUnderground2.WidescreenFix.ini
@@ -6,6 +6,10 @@ FixFOV = 1                               ; Corrects FOV aspect ratio.
 Scaling = 0                              ; Adjusts FOV aspect ratio to be mathematically correct. Requires FixFOV to be enabled.
 HUDWidescreenMode = 1                    ; Moves HUD to the edge of the screen. Change offset in "NFSUnderground2.WidescreenFix.dat" file for other aspect ratios.
 FMVWidescreenMode = 1                    ; FMVs will appear in fullscreen for 16:9. (1 = Cropped | 2 = Stretched)
+FEScale = 1.00                           ; Set the size of UI elements here. (Default = 1.00, Xbox = 0.92)
+FMVScale = 1.00                          ; Set the size of FMVs here. (Default = 1.00)
+AutoFitFE = 0                            ; Automatically fits 16:9 UI content to smaller aspect ratios.
+AutoFitFMV = 1                           ; Automatically scales the FMVs to fully fit the width of the screen. This introduces black bars on aspect ratios smaller than 16:9.
 
 [MISC]
 SkipIntro = 0                            ; Skips FMVs that play when you launch the game.

--- a/source/NFSUnderground.WidescreenFix/dllmain.cpp
+++ b/source/NFSUnderground.WidescreenFix/dllmain.cpp
@@ -15,6 +15,136 @@ struct Screen
     float fHudOffsetReal;
 } Screen;
 
+bool bHUDWidescreenMode = true;
+
+#pragma runtime_checks( "", off )
+namespace FEScale
+{
+    float fFEScale = 1.0f;
+    float fCalcFEScale = 1.0f;
+    float fFMVScale = 1.0f;
+    float fCalcFMVScale = 1.0f;
+    bool bEnabled = false;
+    bool bAutoFitFE = false;
+    bool bAutoFitFMV = true;
+    bool bMovieFlag = false;
+
+    bool bWorkaroundReshade = false;
+
+    uintptr_t SetTransformAddr = 0x00410400;
+    uintptr_t MovieIsStartedAddr = 0x00733F74;
+    uintptr_t InfectedTransform = 0;
+
+    void __stdcall SetTransform(D3DMATRIX* mat, uint32_t EVIEW_ID)
+    {
+        _asm
+        {
+            mov edi, EVIEW_ID
+            push mat
+            call SetTransformAddr
+            add esp, 4
+        }
+    }
+
+    void __stdcall InfectedSetTransform(D3DMATRIX* mat, uint32_t EVIEW_ID)
+    {
+        _asm
+        {
+            mov edi, EVIEW_ID
+            push mat
+            call InfectedTransform
+            add esp, 4
+        }
+    }
+
+    void __cdecl SetTransformHook(D3DMATRIX* mat)
+    {
+        // hooking a fastcall, need to read a register directly...
+        uint32_t EVIEW_ID;
+        _asm mov EVIEW_ID, edi
+
+        D3DMATRIX cMat;
+        memcpy(&cMat, mat, sizeof(D3DMATRIX));
+
+        if (bMovieFlag)
+        {
+            cMat._11 = fCalcFMVScale;
+            cMat._22 = fCalcFMVScale;
+        }
+        else
+        {
+            cMat._11 *= fCalcFEScale;
+            cMat._22 *= fCalcFEScale;
+        }
+
+        if (bWorkaroundReshade)
+            InfectedSetTransform(mat, EVIEW_ID);
+
+        return SetTransform(&cMat, EVIEW_ID);
+    }
+
+    void Update()
+    {
+        fCalcFEScale = fFEScale;
+        fCalcFMVScale = fFMVScale;
+
+        if (bHUDWidescreenMode)
+        {
+            if (bAutoFitFE)
+                fCalcFEScale *= Screen.fAspectRatio / (16.0f / 9.0f);
+            if (bAutoFitFMV)
+                fCalcFMVScale *= Screen.fAspectRatio / (16.0f / 9.0f);
+        }
+        else
+        {
+            if (bAutoFitFE)
+                fCalcFEScale *= Screen.fAspectRatio / (4.0f / 3.0f);
+            if (bAutoFitFMV)
+                fCalcFMVScale *= Screen.fAspectRatio / (4.0f / 3.0f);
+        }
+
+        if (fCalcFEScale > fFEScale)
+            fCalcFEScale = fFEScale;
+
+        if (fCalcFMVScale > fFMVScale)
+            fCalcFMVScale = fFMVScale;
+    }
+
+    uintptr_t DrawFEAddr = 0x00409CD0;
+    
+    void SetMovieFlag()
+    {
+        bMovieFlag = true;
+        // execute a draw call for the FE to set the transform (similar to Pro Street)
+        reinterpret_cast<void(__cdecl*)(uint32_t)>(DrawFEAddr)(0);
+    }
+    
+    void UnsetMovieFlag()
+    {
+        bMovieFlag = false;
+        reinterpret_cast<void(__cdecl*)(uint32_t)>(DrawFEAddr)(0);
+    }
+    
+    struct MovieStartHook
+    {
+        void operator()(injector::reg_pack& regs)
+        {
+            *(uint32_t*)MovieIsStartedAddr = 1;
+            SetMovieFlag();
+        }
+    };
+
+    struct MovieStopHook
+    {
+        void operator()(injector::reg_pack& regs)
+        {
+            *(uint32_t*)MovieIsStartedAddr = 0;
+            UnsetMovieFlag();
+        }
+    };
+}
+#pragma runtime_checks( "", restore )
+
 union HudPos
 {
     uint32_t dwPos;
@@ -308,8 +438,15 @@ void Init()
     bool bFixHUD = iniReader.ReadInteger("MAIN", "FixHUD", 1) != 0;
     bool bFixFOV = iniReader.ReadInteger("MAIN", "FixFOV", 1) != 0;
     bool bScaling = iniReader.ReadInteger("MAIN", "Scaling", 0);
-    bool bHUDWidescreenMode = iniReader.ReadInteger("MAIN", "HUDWidescreenMode", 1) != 0;
+    bHUDWidescreenMode = iniReader.ReadInteger("MAIN", "HUDWidescreenMode", 1) != 0;
     int nFMVWidescreenMode = iniReader.ReadInteger("MAIN", "FMVWidescreenMode", 1);
+    FEScale::fFEScale = iniReader.ReadFloat("MAIN", "FEScale", 1.0f);
+    FEScale::fCalcFEScale = FEScale::fFEScale;
+    FEScale::fFMVScale = iniReader.ReadFloat("MAIN", "FMVScale", 1.0f);
+    FEScale::fCalcFMVScale = FEScale::fFMVScale;
+    FEScale::bAutoFitFE = iniReader.ReadInteger("MAIN", "AutoFitFE", 0) != 0;
+    FEScale::bAutoFitFMV = iniReader.ReadInteger("MAIN", "AutoFitFMV", 1) != 0;
+
     bool bSkipIntro = iniReader.ReadInteger("MISC", "SkipIntro", 0) != 0;
     bool bShowLangSelect = iniReader.ReadInteger("MISC", "ShowLangSelect", 0) != 0;
     static std::filesystem::path CustomUserDir;
@@ -1089,6 +1226,40 @@ void Init()
         // 4. Steering curves get processed at PlayerSteering::CalculateSteeringSpeed                                          <-- THIS IS WHERE THE BUG HAPPENS (or shortly thereafter)
         // 5. Steering value gets passed to the car
         // Skipping 4. is possible by enabling the bool at 00736514, but that is intended exclusively for wheel input and not gamepad/keyboard input.
+    }
+
+    if ((FEScale::fFEScale != 1.0f) || (FEScale::fFMVScale != 1.0f) || (FEScale::bAutoFitFE) || (FEScale::bAutoFitFMV))
+    {
+        FEScale::bEnabled = true;
+
+        uintptr_t loc_409E3C = reinterpret_cast<uintptr_t>(hook::pattern("C7 44 24 18 00 00 80 3F C7 44 24 1C 00 00 00 00").get_first(0)) + 0xBA;
+        uintptr_t loc_5A4A62 = reinterpret_cast<uintptr_t>(hook::pattern("8B 48 14 85 C9 74 ? 8B 11 FF 92 A0 00 00 00 A0").get_first(0)) - 0x90;
+        uintptr_t loc_5A4C02 = reinterpret_cast<uintptr_t>(hook::pattern("83 C4 08 68 B9 0E 96 C3").get_first(0)) - 0x2C;
+        uintptr_t loc_5A4C92 = reinterpret_cast<uintptr_t>(hook::pattern("8A 41 30 84 C0 75 ? 56 C7 05 ? ? ? ? 00 00 00 00").get_first(0)) + 8;
+        uintptr_t loc_40A669 = reinterpret_cast<uintptr_t>(hook::pattern("8B 10 50 FF 92 A4 00 00 00 6A 01 E8").get_first(0)) + 0xB;
+
+        FEScale::SetTransformAddr = static_cast<uintptr_t>(injector::GetBranchDestination(loc_409E3C));
+        FEScale::MovieIsStartedAddr = *reinterpret_cast<uintptr_t*>(loc_5A4A62 + 2);
+        FEScale::DrawFEAddr = static_cast<uintptr_t>(injector::GetBranchDestination(loc_40A669));
+
+        if (FEScale::SetTransformAddr & 0xFF000000)
+        {
+            // NFS reshade workaround -- TODO: remove this once NFS reshade is updated!
+            // reshade in question: https://github.com/xan1242/reshade
+
+            FEScale::bWorkaroundReshade = true;
+            FEScale::InfectedTransform = FEScale::SetTransformAddr;
+
+            uintptr_t loc_40432B = reinterpret_cast<uintptr_t>(hook::pattern("8B 54 24 18 52 E8 ? ? ? ? 83 C4 08").get_first(0)) - 5;
+            FEScale::SetTransformAddr = static_cast<uintptr_t>(injector::GetBranchDestination(loc_40432B));
+        }
+
+        injector::MakeInline<FEScale::MovieStartHook>(loc_5A4A62, loc_5A4A62 + 0xA);
+        injector::MakeInline<FEScale::MovieStopHook>(loc_5A4C02, loc_5A4C02 + 0xA);
+        injector::MakeInline<FEScale::MovieStopHook>(loc_5A4C92, loc_5A4C92 + 0xA);
+        injector::MakeCALL(loc_409E3C, FEScale::SetTransformHook);
+
+        FEScale::Update();
     }
 
     // windowed mode

--- a/source/NFSUnderground2.WidescreenFix/dllmain.cpp
+++ b/source/NFSUnderground2.WidescreenFix/dllmain.cpp
@@ -16,6 +16,7 @@ struct Screen
 
 bool bHUDWidescreenMode;
 
+#pragma runtime_checks( "", off )
 namespace FEScale
 {
     float fFEScale = 1.0f;
@@ -107,6 +108,7 @@ namespace FEScale
         reinterpret_cast<void(*)()>(eWaitUntilRenderingDone)();
     }
 }
+#pragma runtime_checks( "", restore )
 
 union HudPos
 {

--- a/source/NFSUnderground2.WidescreenFix/dllmain.cpp
+++ b/source/NFSUnderground2.WidescreenFix/dllmain.cpp
@@ -1,5 +1,5 @@
 #include "stdafx.h"
-#include "GTA\CFileMgr.h"
+#include <d3d9.h>
 
 struct Screen
 {
@@ -13,6 +13,100 @@ struct Screen
     float fHudPosX;
     float fHudOffset;
 } Screen;
+
+bool bHUDWidescreenMode;
+
+namespace FEScale
+{
+    float fFEScale = 1.0f;
+    float fCalcFEScale = 1.0f;
+    float fFMVScale = 1.0f;
+    float fCalcFMVScale = 1.0f;
+    bool bEnabled = false;
+    bool bAutoFitFE = false;
+    bool bAutoFitFMV = true;
+    bool bMovieFlag = false;
+
+    uintptr_t SetTransformAddr = 0x005BDDE0;
+    uintptr_t MovieIsStartedAddr = 0x008383AC;
+
+    void __cdecl SetTransformHook(D3DMATRIX* mat, uint32_t EVIEW_ID)
+    {
+        D3DMATRIX cMat;
+        memcpy(&cMat, mat, sizeof(D3DMATRIX));
+
+        if (bMovieFlag)
+        {
+            cMat._11 = fCalcFMVScale;
+            cMat._22 = fCalcFMVScale;
+        }
+        else
+        {
+            cMat._11 *= fCalcFEScale;
+            cMat._22 *= fCalcFEScale;
+        }
+
+        return reinterpret_cast<void(__cdecl*)(D3DMATRIX*, uint32_t)>(SetTransformAddr)(&cMat, EVIEW_ID);
+    }
+
+    void Update()
+    {
+        fCalcFEScale = fFEScale;
+        fCalcFMVScale = fFMVScale;
+
+        if (bHUDWidescreenMode)
+        {
+            if (bAutoFitFE)
+                fCalcFEScale *= Screen.fAspectRatio / (16.0f / 9.0f);
+            if (bAutoFitFMV)
+                fCalcFMVScale *= Screen.fAspectRatio / (16.0f / 9.0f);
+        }
+        else
+        {
+            if (bAutoFitFE)
+                fCalcFEScale *= Screen.fAspectRatio / (4.0f / 3.0f);
+            if (bAutoFitFMV)
+                fCalcFMVScale *= Screen.fAspectRatio / (4.0f / 3.0f);
+        }
+
+        if (fCalcFEScale > fFEScale)
+            fCalcFEScale = fFEScale;
+
+        if (fCalcFMVScale > fFMVScale)
+            fCalcFMVScale = fFMVScale;
+    }
+
+    uintptr_t DrawFEAddr = 0x005CBF40;
+    uintptr_t eWaitUntilRenderingDone = 0x004022C0;
+
+    void SetMovieFlag()
+    {
+        bMovieFlag = true;
+        // execute a draw call for the FE to set the transform (similar to Pro Street)
+        reinterpret_cast<void(__cdecl*)(uint32_t)>(DrawFEAddr)(0);
+    }
+
+    void UnsetMovieFlag()
+    {
+        bMovieFlag = false;
+        reinterpret_cast<void(__cdecl*)(uint32_t)>(DrawFEAddr)(0);
+    }
+
+    struct MovieStartHook
+    {
+        void operator()(injector::reg_pack& regs)
+        {
+            *(uint32_t*)MovieIsStartedAddr = 1;
+            SetMovieFlag();
+        }
+    };
+
+    void eWaitUntilRenderingDoneHook()
+    {
+        UnsetMovieFlag();
+        reinterpret_cast<void(*)()>(eWaitUntilRenderingDone)();
+    }
+}
 
 union HudPos
 {
@@ -75,22 +169,25 @@ HANDLE WINAPI CustomCreateThread(LPSECURITY_ATTRIBUTES lpThreadAttributes, SIZE_
     return hThread;
 }
 
-static uint32_t NOSTrailFrameDelay = 1;
-uint32_t* eFrameCounter_870818 = (uint32_t*)0x00870818;
-uint32_t* fc_12989_8A44EC = (uint32_t*)0x008A44EC;
-uint32_t* NOSTrailCaveExitTrue = (uint32_t*)0x0061AD91;
-uint32_t* NOSTrailCaveExitFalse = (uint32_t*)0x61AE8E;
-void __declspec(naked) NOSTrailCave()
+namespace NOSTrailFix
 {
-    if ((*fc_12989_8A44EC + NOSTrailFrameDelay) <= *eFrameCounter_870818)
-        _asm
+    static uint32_t NOSTrailFrameDelay = 1;
+    uint32_t* eFrameCounter_870818 = (uint32_t*)0x00870818;
+    uint32_t* fc_12989_8A44EC = (uint32_t*)0x008A44EC;
+    uint32_t* NOSTrailCaveExitTrue = (uint32_t*)0x0061AD91;
+    uint32_t* NOSTrailCaveExitFalse = (uint32_t*)0x61AE8E;
+    void __declspec(naked) NOSTrailCave()
+    {
+        if ((*fc_12989_8A44EC + NOSTrailFrameDelay) <= *eFrameCounter_870818)
+            _asm
         {
             mov eax, ds:eFrameCounter_870818
             mov eax, [eax]
             jmp NOSTrailCaveExitTrue
         }
-    else
-        _asm jmp NOSTrailCaveExitFalse
+        else
+            _asm jmp NOSTrailCaveExitFalse
+    }
 }
 
 void Init()
@@ -101,8 +198,15 @@ void Init()
     bool bFixHUD = iniReader.ReadInteger("MAIN", "FixHUD", 1) != 0;
     bool bFixFOV = iniReader.ReadInteger("MAIN", "FixFOV", 1) != 0;
     bool bScaling = iniReader.ReadInteger("MAIN", "Scaling", 0) != 0;
-    bool bHUDWidescreenMode = iniReader.ReadInteger("MAIN", "HUDWidescreenMode", 1) != 0;
+    bHUDWidescreenMode = iniReader.ReadInteger("MAIN", "HUDWidescreenMode", 1) != 0;
     int nFMVWidescreenMode = iniReader.ReadInteger("MAIN", "FMVWidescreenMode", 1);
+    FEScale::fFEScale = iniReader.ReadFloat("MAIN", "FEScale", 1.0f);
+    FEScale::fCalcFEScale = FEScale::fFEScale;
+    FEScale::fFMVScale = iniReader.ReadFloat("MAIN", "FMVScale", 1.0f);
+    FEScale::fCalcFMVScale = FEScale::fFMVScale;
+    FEScale::bAutoFitFE = iniReader.ReadInteger("MAIN", "AutoFitFE", 0) != 0;
+    FEScale::bAutoFitFMV = iniReader.ReadInteger("MAIN", "AutoFitFMV", 1) != 0;
+
     bool bSkipIntro = iniReader.ReadInteger("MISC", "SkipIntro", 0) != 0;
     bool bDisableCutsceneBorders = iniReader.ReadInteger("MISC", "DisableCutsceneBorders", 1) != 0;
 
@@ -814,6 +918,30 @@ void Init()
         injector::WriteMemory<uint8_t>(dword_5C0D54, 0x00, true);
     }
 
+    if ((FEScale::fFEScale != 1.0f) || (FEScale::fFMVScale != 1.0f) || (FEScale::bAutoFitFE) || (FEScale::bAutoFitFMV))
+    {
+        FEScale::bEnabled = true;
+
+        uintptr_t loc_5CC08D = reinterpret_cast<uintptr_t>(hook::pattern("C7 44 24 2C 00 00 80 3F 8B 10 50").get_first(0)) + 0xDE;
+        uintptr_t loc_566042 = reinterpret_cast<uintptr_t>(hook::pattern("6A 00 68 B9 0E 96 C3 B9 ? ? ? ? E8 ? ? ? ? 59").get_first(0)) + 0x18;
+        uintptr_t loc_5D2B18 = reinterpret_cast<uintptr_t>(hook::pattern("FF 91 A4 00 00 00 6A 01 E8").get_first(0)) + 8;
+        uintptr_t loc_511BD9 = reinterpret_cast<uintptr_t>(hook::pattern("8A 48 34 84 C9 0F 85 ? ? ? ? 55").get_first(0)) + 0xC;
+        uintptr_t loc_566197 = reinterpret_cast<uintptr_t>(hook::pattern("68 00 01 00 00 51 8D 54 24 14").get_first(0)) + 0x13;
+
+
+        FEScale::SetTransformAddr = static_cast<uintptr_t>(injector::GetBranchDestination(loc_5CC08D));
+        FEScale::MovieIsStartedAddr = *reinterpret_cast<uintptr_t*>(loc_566042 + 2);
+        FEScale::DrawFEAddr = static_cast<uintptr_t>(injector::GetBranchDestination(loc_5D2B18));
+        FEScale::eWaitUntilRenderingDone = static_cast<uintptr_t>(injector::GetBranchDestination(loc_511BD9));
+        
+        injector::MakeInline<FEScale::MovieStartHook>(loc_566042, loc_566042 + 0xA);
+        injector::MakeCALL(loc_511BD9, FEScale::eWaitUntilRenderingDoneHook);
+        injector::MakeCALL(loc_566197, FEScale::eWaitUntilRenderingDoneHook);
+        injector::MakeCALL(loc_5CC08D, FEScale::SetTransformHook);
+
+        FEScale::Update();
+    }
+
     if (bWriteSettingsToFile)
     {
         std::filesystem::path SettingsSavePath;
@@ -927,14 +1055,14 @@ void Init()
 
         static uint32_t NOSTargetFPS = 60; // original FPS we're targeting from. Consoles target 60 but run at 30, hence have longer trails than PC. Targeting 60 is smarter due to less issues with shorter trails. Use SimRate -2 to get the same effect as console versions.
         static float fNOSTrailFrameDelay = ((float)TargetRate / (float)NOSTargetFPS) * fCustomNOSTrailLength;
-        NOSTrailFrameDelay = (uint32_t)round(fNOSTrailFrameDelay);
+        NOSTrailFix::NOSTrailFrameDelay = (uint32_t)round(fNOSTrailFrameDelay);
 
         pattern = hook::pattern("81 C1 15 02 00 00 C1 E1 04"); // 0x0061AE69
-        eFrameCounter_870818 = *pattern.count(1).get(0).get<uint32_t*>(-0xE8);
-        fc_12989_8A44EC = *pattern.count(1).get(0).get<uint32_t*>(-0xE2);
-        NOSTrailCaveExitTrue = (uint32_t*)pattern.get_first(-0xD8);
-        NOSTrailCaveExitFalse = (uint32_t*)pattern.get_first(0x25);
-        injector::MakeJMP(pattern.get_first(-0xE9), NOSTrailCave, true);
+        NOSTrailFix::eFrameCounter_870818 = *pattern.count(1).get(0).get<uint32_t*>(-0xE8);
+        NOSTrailFix::fc_12989_8A44EC = *pattern.count(1).get(0).get<uint32_t*>(-0xE2);
+        NOSTrailFix::NOSTrailCaveExitTrue = (uint32_t*)pattern.get_first(-0xD8);
+        NOSTrailFix::NOSTrailCaveExitFalse = (uint32_t*)pattern.get_first(0x25);
+        injector::MakeJMP(pattern.get_first(-0xE9), NOSTrailFix::NOSTrailCave, true);
     }
 }
 


### PR DESCRIPTION
Same deal as MW and Carbon scalers pretty much.

I had to do some exotic workarounds due to my own stupidity (my Reshade fork hooks the same place in UG1).

HUD auto fitting isn't necessary as that's done automatically, therefore it's been disabled by default.

FMVs on the other hand benefit on 16:10 displays by having more height to display.