### PR TITLE
[NFSMW/C/PS] add FE scaling interop with XtendedInput

### DIFF
--- a/source/NFSMostWanted.WidescreenFix/dllmain.cpp
+++ b/source/NFSMostWanted.WidescreenFix/dllmain.cpp
@@ -1388,8 +1388,6 @@ void Init()
 
         injector::MakeCALL(loc_6E6FB7, FEScale::SetTransformHook);
         injector::MakeCALL(loc_6E7011, FEScale::SetTransformHook);
-
-        //FEScale::Update();
     }
 
     if (bWriteSettingsToFile)


### PR DESCRIPTION
As fixing the mouse is practically impossible without what XtendedInput does already, I've just decided to scale the window size from within XtendedInput to resolve this issue.

Done in coordination with this commit: https://github.com/xan1242/NFS-XtendedInput/commit/6567430e21db80cdac380a8b26bb8fe0a3cd981e

I'll also upload a new build of XtendedInput with these changes.

Underground & 2 will have to wait until I decide to update its XtendedInput.