### PR TITLE
[NFSU] Remove Best Lap Time from Results Screen

### DIFF
--- a/source/NFSUnderground.WidescreenFix/dllmain.cpp
+++ b/source/NFSUnderground.WidescreenFix/dllmain.cpp
@@ -1316,8 +1316,10 @@ void Init()
 
     // Disable the best lap time counter at the end of the race for better ultrawide support
     // (this element is not visible during 16:9 play)
+    auto loc_49A222 = hook::pattern("8A 44 24 24 8B 6C 24 68 8B 7D 0C 83 CE FF 84 C0 8D 4C 24 24 74 1A");
     pattern = hook::pattern("0F 84 B8 00 00 00 8D 4C 24 44");
-    injector::WriteMemory(pattern.get_first(1), (int8_t)0x85, true);
+    injector::MakeNOP(pattern.get_first(0), 6, true);
+    injector::MakeJMP(pattern.get_first(0), loc_49A222.get_first(0), true);
 }
 
 CEXP void InitializeASI()

--- a/source/NFSUnderground.WidescreenFix/dllmain.cpp
+++ b/source/NFSUnderground.WidescreenFix/dllmain.cpp
@@ -1316,7 +1316,7 @@ void Init()
 
     // Disable the best lap time counter at the end of the race for better ultrawide support
     // (this element is not visible during 16:9 play)
-    auto loc_49A222 = hook::pattern("8A 44 24 24 8B 6C 24 68 8B 7D 0C 83 CE FF 84 C0 8D 4C 24 24 74 1A");
+    auto loc_49A222 = hook::pattern("8A 44 24 24 8B 6C 24 68 8B 7D 0C 83 CE FF 84 C0 8D 4C 24 24 74 ? 6B F6 21");
     pattern = hook::pattern("0F 84 B8 00 00 00 8D 4C 24 44");
     injector::MakeNOP(pattern.get_first(0), 6, true);
     injector::MakeJMP(pattern.get_first(0), loc_49A222.get_first(0), true);

--- a/source/NFSUnderground.WidescreenFix/dllmain.cpp
+++ b/source/NFSUnderground.WidescreenFix/dllmain.cpp
@@ -1313,6 +1313,11 @@ void Init()
         injector::MakeNOP(pattern.get_first(0), 6, true);
         injector::MakeCALL(pattern.get_first(0), static_cast<void(WINAPI*)(HWND, int, LONG)>(SetWindowLongHook), true);
     }
+
+    // Disable the best lap time counter at the end of the race for better ultrawide support
+    // (this element is not visible during 16:9 play)
+    pattern = hook::pattern("0F 84 B8 00 00 00 8D 4C 24 44");
+    injector::WriteMemory(pattern.get_first(1), (int8_t)0x85, true);
 }
 
 CEXP void InitializeASI()


### PR DESCRIPTION
Added code that flips the if statement for if the best lap time should be displayed on the results screen or not.

This doesn't change behaviour for 16:9 displays, as the best lap hud element falls outside of the 16:9 aspect ratio range but on 21:9 displays an extra piece of text is visible.

![image](https://github.com/ThirteenAG/WidescreenFixesPack/assets/55578911/7aec7ebf-cd92-4a59-87bf-d090ea1c755a)
![image](https://github.com/ThirteenAG/WidescreenFixesPack/assets/55578911/2dc076a7-7792-47cc-9654-b9563d1358c1)
