### PR TITLE
THPS4: Fix for field of view not being aspect corrected

### DIFF
--- a/data/TonyHawksProSkater4.WidescreenFix/Game/scripts/TonyHawksProSkater4.WidescreenFix.ini
+++ b/data/TonyHawksProSkater4.WidescreenFix/Game/scripts/TonyHawksProSkater4.WidescreenFix.ini
@@ -2,5 +2,5 @@
 ResX = 0
 ResY = 0
 FixHUD = 1
-FovScale = 1
+CustomFov = 0
 RandomSongOrderFix = 1

--- a/data/TonyHawksProSkater4.WidescreenFix/Game/scripts/TonyHawksProSkater4.WidescreenFix.ini
+++ b/data/TonyHawksProSkater4.WidescreenFix/Game/scripts/TonyHawksProSkater4.WidescreenFix.ini
@@ -2,4 +2,5 @@
 ResX = 0
 ResY = 0
 FixHUD = 1
+FovScale = 1
 RandomSongOrderFix = 1

--- a/data/TonyHawksProSkater4.WidescreenFix/Game/scripts/TonyHawksProSkater4.WidescreenFix.ini
+++ b/data/TonyHawksProSkater4.WidescreenFix/Game/scripts/TonyHawksProSkater4.WidescreenFix.ini
@@ -2,5 +2,5 @@
 ResX = 0
 ResY = 0
 FixHUD = 1
-CustomFov = 0
+FOVFactor = 1.0
 RandomSongOrderFix = 1

--- a/source/TonyHawksProSkater4.WidescreenFix/dllmain.cpp
+++ b/source/TonyHawksProSkater4.WidescreenFix/dllmain.cpp
@@ -11,7 +11,7 @@ struct Screen
     float fAspectRatio;
     float fAspectRatioDiff;
     float fFieldOfView;
-    float fFovScale;
+    float fCustomFov;
     float fHUDScaleX;
     float fHudOffset;
     float fHudOffsetReal;
@@ -24,7 +24,7 @@ void Init()
     Screen.Height = iniReader.ReadInteger("MAIN", "ResY", 0);
     bool bFixHUD = iniReader.ReadInteger("MAIN", "FixHUD", 1) != 0;
     bool bRandomSongOrderFix = iniReader.ReadInteger("MAIN", "RandomSongOrderFix", 1) != 0;
-    Screen.fFovScale = iniReader.ReadFloat("MAIN", "FovScale", 1);
+    Screen.fCustomFov = iniReader.ReadFloat("MAIN", "CustomFov", 0);
 
     if (!Screen.Width || !Screen.Height)
         std::tie(Screen.Width, Screen.Height) = GetDesktopRes();
@@ -71,20 +71,11 @@ void Init()
     {
         void operator()(injector::reg_pack& regs)
         {
-            float fov = 0.0f;
-            _asm {fst dword ptr[fov]}
-            *(float*)(regs.esi + 0xA4) = AdjustFOV(fov, Screen.fAspectRatio);
+            float fov = *(float*)(regs.esi + 0xA4);
+            float adjustedFov = AdjustFOV(fov, Screen.fAspectRatio);
+            *(float*)(regs.esi + 0xA0) = (Screen.fCustomFov) ? Screen.fCustomFov : adjustedFov;
         }
     }; injector::MakeInline<FovHook>(pattern.get_first(0), pattern.get_first(6));
-
-    //FovScale
-    pattern = hook::pattern("d9 05 ? ? ? ? c3 90 90 90 90 90 90 90 90 90 8b 4c 24");
-    float* fovscaleAddress = *pattern.get_first<float*>(2);
-
-    pattern = hook::pattern("D9 1D ? ? ? ? 7E 4F 8B 15 ? ? ? ? 33 C9 33 C0");
-    injector::MakeNOP(pattern.get_first(0), 6, true);
-
-    *fovscaleAddress = Screen.fFovScale;
 
     //HUD
     if (bFixHUD)

--- a/source/TonyHawksProSkater4.WidescreenFix/dllmain.cpp
+++ b/source/TonyHawksProSkater4.WidescreenFix/dllmain.cpp
@@ -11,7 +11,7 @@ struct Screen
     float fAspectRatio;
     float fAspectRatioDiff;
     float fFieldOfView;
-    float fCustomFov;
+    float fFOVFactor;
     float fHUDScaleX;
     float fHudOffset;
     float fHudOffsetReal;
@@ -24,7 +24,7 @@ void Init()
     Screen.Height = iniReader.ReadInteger("MAIN", "ResY", 0);
     bool bFixHUD = iniReader.ReadInteger("MAIN", "FixHUD", 1) != 0;
     bool bRandomSongOrderFix = iniReader.ReadInteger("MAIN", "RandomSongOrderFix", 1) != 0;
-    Screen.fCustomFov = iniReader.ReadFloat("MAIN", "CustomFov", 0);
+    Screen.fFOVFactor = iniReader.ReadFloat("MAIN", "FOVFactor", 0.0f);
 
     if (!Screen.Width || !Screen.Height)
         std::tie(Screen.Width, Screen.Height) = GetDesktopRes();
@@ -37,6 +37,8 @@ void Init()
     Screen.fHUDScaleX = 1.0f / Screen.fWidth * (Screen.fHeight / 480.0f);
     Screen.fHudOffset = ((480.0f * Screen.fAspectRatio) - 640.0f) / 2.0f;
     Screen.fHudOffsetReal = (Screen.fWidth - Screen.fHeight * (4.0f / 3.0f)) / 2.0f;
+    if (Screen.fFOVFactor <= 0.0f)
+        Screen.fFOVFactor = 1.0f;
 
     //Resolution
     auto pattern = hook::pattern("8B 4C B4 20 89 15");
@@ -73,7 +75,7 @@ void Init()
         {
             float fov = *(float*)(regs.esi + 0xA4);
             float adjustedFov = AdjustFOV(fov, Screen.fAspectRatio);
-            *(float*)(regs.esi + 0xA0) = (Screen.fCustomFov) ? Screen.fCustomFov : adjustedFov;
+            *(float*)(regs.esi + 0xA0) = adjustedFov * Screen.fFOVFactor;
         }
     }; injector::MakeInline<FovHook>(pattern.get_first(0), pattern.get_first(6));
 


### PR DESCRIPTION
Currently the field of view for the game seems fairly low at the default settings even when aspect corrected. This change allows for the user to change what the fov scaling is for the regular in game camera.

Example default settings:
![before](https://github.com/ThirteenAG/WidescreenFixesPack/assets/35150944/d3518e83-69ae-45e9-a716-e519a5299e51)

Fov scale set to 1.4:
![after](https://github.com/ThirteenAG/WidescreenFixesPack/assets/35150944/1fa11666-8d1e-4af9-af13-93bf1b0c76b4)