### PR TITLE
[Sonic Heroes] add demo/trial version detection

### DIFF
--- a/data/SonicHeroes.WidescreenFix/scripts/SonicHeroes.WidescreenFix.ini
+++ b/data/SonicHeroes.WidescreenFix/scripts/SonicHeroes.WidescreenFix.ini
@@ -13,13 +13,13 @@ ClipRange = 1.0                          ; Set the RW camera clipping range. Onl
 FixLensFlare = 1                         ; Fixes lens flare effect by scaling it to the screen size.
 FixAdvertiseWindows = 1                  ; Fixes Advertise menu window sizes.
 FixStaffRoll = 1                         ; Fixes the staff roll / credits.
-DisableCDCheck = 1                       ; Allows the game to be run without a inserted CD.
+DisableCDCheck = 1                       ; Allows the game to be run without a inserted CD. (Retail build only)
 DisableMouseInput = 1                    ; Disables mouse input. Useful for Windowed mode.
 DisableFrameSkipping = 1                 ; Disables frame skipping entirely.
 DisableQuitDialog = 0                    ; Disables the "End the game?" dialog box when the game window is being closed through Windows (Alt+F4, X on the window).
 DisableLoadingTimer = 0                  ; Disables the loading screen timeout.
 DisableSubtitles = 0                     ; Prevents subtitles from being displayed.
-RestoreDemos = 1                         ; Restores attract demos on the title screen.
+RestoreDemos = 1                         ; Restores attract demos on the title screen. (Retail build only)
 IncreaseObjectDistance = 1               ; Enables object visibility distance adjustment by MinObjDistance and ObjDistanceScale. Reduces object pop-in.
 MinObjDistance = 0                       ; Minimum object distance (Min = 0, Max = 255, Default = 0)
 ObjDistanceScale = 2.0                   ; Object distance scalar. (Min = 0.0, Max = 255.0, Default = 2.0)

--- a/source/SonicHeroes.WidescreenFix/dllmain.cpp
+++ b/source/SonicHeroes.WidescreenFix/dllmain.cpp
@@ -659,6 +659,15 @@ void Init()
 	if (szCustomUserFilesDirectoryInGameDir.empty() || szCustomUserFilesDirectoryInGameDir == "0")
 		szCustomUserFilesDirectoryInGameDir.clear();
 
+	// demo/trial version detect -- the string for the user directory is different in these builds
+	static bool bDemoVersion = false;
+	uintptr_t loc_629D23 = reinterpret_cast<uintptr_t>(hook::pattern("? ? ? 6A 1A ? FF 15").get_first(0)) + 0x12;
+	char* userPath = *(char**)(loc_629D23 + 1);
+	if (strstr(userPath, "TRIAL") || strstr(userPath, "DEMO"))
+	{
+		bDemoVersion = true;
+	}
+
 	// SkipFE-like functions for Sonic Heroes
 	// credit to: https://github.com/Sewer56/Heroes.Utils.DebugBoot.ReloadedII
 	static bool bSkipFE = iniReader.ReadInteger("SkipFE", "Enabled", 0) != 0;
@@ -1424,7 +1433,8 @@ void Init()
 		injector::MakeJMP(loc_402CF5, loc_402CF5 + 0x2B);
 	}
 
-	if (bRestoreDemos)
+	// does not exist in demo!
+	if (bRestoreDemos && !bDemoVersion)
 	{
 		uintptr_t loc_456989 = reinterpret_cast<uintptr_t>(hook::pattern("C7 05 ? ? ? ? 06 00 00 00 EB 14 C7 05 ? ? ? ? 03 00 00 00 C7 05 ? ? ? ? 0A 00 00 00").get_first(0)) + 0x23;
 		DemoRestoreExit1 = loc_456989 + 7;
@@ -1447,7 +1457,8 @@ void Init()
 		}; injector::MakeInline<SysModeHook>(loc_42713E, loc_42713E + 0xB);
 	}
 
-	if (bDisableCDCheck)
+	// does not exist in demo!
+	if (bDisableCDCheck && !bDemoVersion)
 	{
 		uintptr_t loc_629B72 = reinterpret_cast<uintptr_t>(hook::pattern("55 8B EC 83 E4 F8 83 EC 50 53 55 56 57 68 00 00 40 00 6A 00 6A 00").get_first(0)) + 0x42;
 		injector::MakeJMP(loc_629B72, loc_629B72 + 0xC4, true);


### PR DESCRIPTION
Added a detect for the demo version (which can be freely obtained from [Hidden Palace](https://hiddenpalace.org/Sonic_Heroes_(Nov_9,_2004_demo)))

It doesn't have the code for the demo mode and CD checks, so those are disabled for this build