### PR TITLE
Restore FixHud option for Max Payne 1 & 2

### DIFF
--- a/data/MaxPayne.WidescreenFix/scripts/MaxPayne.WidescreenFix.ini
+++ b/data/MaxPayne.WidescreenFix/scripts/MaxPayne.WidescreenFix.ini
@@ -1,6 +1,6 @@
 [MAIN]
 FixHud = 1 // Corrects aspect ratio of all 2d graphics, might have issues with mods.
-WidescreenHud = 1 // Makes selected hud elements offset to screen edges.
+WidescreenHud = 1 // Makes selected hud elements offset to screen edges. Use with FixHud = 1.
 WidescreenHudOffset = 100.0 // This is the default offset for 16:9. For lower aspect ratios adjusted automatically, for higher you may change it manually.
 FOVFactor = 1.0 // Makes FOV higher or lower. 1.0 by default.
 GraphicNovelMode = 0 

--- a/data/MaxPayne.WidescreenFix/scripts/MaxPayne.WidescreenFix.ini
+++ b/data/MaxPayne.WidescreenFix/scripts/MaxPayne.WidescreenFix.ini
@@ -1,4 +1,5 @@
 [MAIN]
+FixHud = 1 // Corrects aspect ratio of all 2d graphics, might have issues with mods.
 WidescreenHud = 1 // Makes selected hud elements offset to screen edges.
 WidescreenHudOffset = 100.0 // This is the default offset for 16:9. For lower aspect ratios adjusted automatically, for higher you may change it manually.
 FOVFactor = 1.0 // Makes FOV higher or lower. 1.0 by default.

--- a/data/MaxPayne.WidescreenFix/scripts/MaxPayne.WidescreenFix.ini
+++ b/data/MaxPayne.WidescreenFix/scripts/MaxPayne.WidescreenFix.ini
@@ -1,5 +1,5 @@
 [MAIN]
-FixHud = 1 // Corrects aspect ratio of all 2d graphics, might have issues with mods.
+FixHud = 1 // Corrects aspect ratio of all 2d graphics, might have issues with mods that add effects like Vignette.
 WidescreenHud = 1 // Makes selected hud elements offset to screen edges. Use with FixHud = 1.
 WidescreenHudOffset = 100.0 // This is the default offset for 16:9. For lower aspect ratios adjusted automatically, for higher you may change it manually.
 FOVFactor = 1.0 // Makes FOV higher or lower. 1.0 by default.

--- a/data/MaxPayne.WidescreenFix/scripts/MaxPayne.WidescreenFix.ini
+++ b/data/MaxPayne.WidescreenFix/scripts/MaxPayne.WidescreenFix.ini
@@ -1,5 +1,5 @@
 [MAIN]
-FixHud = 1 // Corrects aspect ratio of all 2d graphics, might have issues with mods that add effects like Vignette.
+FixHud = 1 // Corrects aspect ratio of all 2d graphics, might have issues with mods.
 WidescreenHud = 1 // Makes selected hud elements offset to screen edges. Use with FixHud = 1.
 WidescreenHudOffset = 100.0 // This is the default offset for 16:9. For lower aspect ratios adjusted automatically, for higher you may change it manually.
 FOVFactor = 1.0 // Makes FOV higher or lower. 1.0 by default.

--- a/data/MaxPayne2.WidescreenFix/scripts/MaxPayne2.WidescreenFix.ini
+++ b/data/MaxPayne2.WidescreenFix/scripts/MaxPayne2.WidescreenFix.ini
@@ -1,4 +1,5 @@
 [MAIN]
+FixHud = 1 // Corrects aspect ratio of all 2d graphics, will have issues with mods such as Payne Evolution and Payne Effects 3.
 WidescreenHud = 1 // Makes selected hud elements offset to screen edges.
 WidescreenHudOffset = 100.0 // This is the default offset for 16:9. For lower aspect ratios adjusted automatically, for higher you may change it manually.
 FOVFactor = 1.0 // Makes FOV higher or lower. 1.0 by default.

--- a/data/MaxPayne2.WidescreenFix/scripts/MaxPayne2.WidescreenFix.ini
+++ b/data/MaxPayne2.WidescreenFix/scripts/MaxPayne2.WidescreenFix.ini
@@ -1,5 +1,5 @@
 [MAIN]
-FixHud = 1 // Corrects aspect ratio of all 2d graphics, will have issues with mods such as Payne Evolution and Payne Effects 3.
+FixHud = 1 // Corrects aspect ratio of all 2d graphics, might have issues with mods.
 WidescreenHud = 1 // Makes selected hud elements offset to screen edges. Use with FixHud = 1.
 WidescreenHudOffset = 100.0 // This is the default offset for 16:9. For lower aspect ratios adjusted automatically, for higher you may change it manually.
 FOVFactor = 1.0 // Makes FOV higher or lower. 1.0 by default.

--- a/data/MaxPayne2.WidescreenFix/scripts/MaxPayne2.WidescreenFix.ini
+++ b/data/MaxPayne2.WidescreenFix/scripts/MaxPayne2.WidescreenFix.ini
@@ -1,6 +1,6 @@
 [MAIN]
 FixHud = 1 // Corrects aspect ratio of all 2d graphics, will have issues with mods such as Payne Evolution and Payne Effects 3.
-WidescreenHud = 1 // Makes selected hud elements offset to screen edges.
+WidescreenHud = 1 // Makes selected hud elements offset to screen edges. Use with FixHud = 1.
 WidescreenHudOffset = 100.0 // This is the default offset for 16:9. For lower aspect ratios adjusted automatically, for higher you may change it manually.
 FOVFactor = 1.0 // Makes FOV higher or lower. 1.0 by default.
 GraphicNovelMode = 0 


### PR DESCRIPTION
There are mods like Payne Evolution or Payne Effects 3 that have some unadjusted effects when using the fixed hud and due to that you have to use old versions of the fix when using them, so restoring that option would be worth it.