### PR TITLE
[Call of Cthulhu] Fixed Inventory Menu Cursor Boxes and Heart Rate Monitor

### DIFF
--- a/source/CallOfCthulhu.WidescreenFix/dllmain.cpp
+++ b/source/CallOfCthulhu.WidescreenFix/dllmain.cpp
@@ -11,6 +11,8 @@ struct Screen
     float fHudOffset;
     float fTextOffset;
     float fFMVOffset;
+    float fInvMenuHeartLineEnd; // On-Screen Range: -0.5 to 0.5
+    float fInvMenuHeartLineWidth; // Full Screen Width is 0.002
 } Screen;
 
 void Init()
@@ -43,32 +45,39 @@ void Init()
             }
 
             // InventoryMenu - BlackBox (covers top-right line paper)
-            int codePushZeroPush = 0x68006A; // 6A00 = push 0x00; 68 = push (next value)
-            injector::WriteMemory<int>(0x422B1A, codePushZeroPush, true); // y = 0
-            injector::WriteMemory<float>(0x422B1D, 1.0f, true); // x = 1
-            injector::WriteMemory<float>(0x422B27, (4.0f / 3.0f) * Screen.fHudOffset / Screen.Width, true); // w
-            injector::WriteMemory<float>(0x422B33, 1.0f, true); // h = 1
+            pattern = hook::pattern("68 D7 A3 30 3F 6A 00"); // 422B1A
+            const uint32_t codePushZeroPush = 0x68006A; // 6A 00 = push 0x00; 68 = push (next value)
+            const float blackBoxWidth = (4.0f / 3.0f) * Screen.fHudOffset / Screen.Width;
+            injector::WriteMemory(pattern.get_first(0), codePushZeroPush, true); // y = 0
+            injector::WriteMemory(pattern.get_first(3), 1.0f, true); // x = 1
+            pattern = hook::pattern("68 E1 7A 14 3F ? ? ? ? ? ? ? 68 52 B8 9E 3E"); // 422B26
+            injector::WriteMemory(pattern.get_first(1), blackBoxWidth, true); // w
+            injector::WriteMemory(pattern.get_first(13), 1.0f, true); // h = 1
 
             // InventoryMenu - HeartMonitorLine (positioned on line paper)
-            // NOTE: HeartMonitorLine ends at 103% ScreenWidth (i.e. 3% off-screen)
-            float HeartMonitorLineEndX = 0.53f; // ReadMemory(0x62D630); // On-Screen Range: -0.5 to 0.5
-            float HeartMonitorLineWidth = 0.000775f; // ReadMemory(0x62D794); // ScreenWidth is 0.002
-            injector::WriteMemory<float>(0x62D630, (HeartMonitorLineEndX - 0.03f) * Screen.fHudScale, true);
-            injector::WriteMemory<float>(0x62D794, (HeartMonitorLineWidth - 0.00006f) * Screen.fHudScale, true);
+            // NOTE: HeartMonitorLine ended at 103% ScreenWidth (i.e. 3% off-screen) in OG game.
+            pattern = hook::pattern("D8 0D ? ? ? ? 85 C9 DB"); // 424FD8; [????] = 0.53
+            Screen.fInvMenuHeartLineEnd = Screen.fHudScale * 0.5f; // 50% instead of 53% so line doesn't go past screen edge
+            injector::WriteMemory(pattern.get_first(2), &Screen.fInvMenuHeartLineEnd, true);
+            pattern = hook::pattern("D8 0D ? ? ? ? 8B 44 24 ? 85 C0"); // 425DC8; [????] = 0.000775
+            Screen.fInvMenuHeartLineWidth = Screen.fHudScale * 0.000715f; // Subtracted 0.00006 (3% + 3%)
+            injector::WriteMemory(pattern.get_first(2), &Screen.fInvMenuHeartLineWidth, true);
 
             // HealMenu - Fix Cursor Boxes
-            // NOTE: Cursor is off by one small square even in the OG game (fixed)
-            float HealMenuBoxWidth = 26.087f; // ReadMemory(0x62D5D4);
-            float HealMenuCursorXMin = 0.35f; // ReadMemory(0x62D5D8);
-            float HealMenuCursorXMax = 0.58f; // ReadMemory(0x62D5E4);
-            float HealMenuCursorYMax = 0.87f; // ReadMemory(0x62D5DC);
-            float HealMenuCursorYMin = 0.635f; // ReadMemory(0x62D5E0);
-            float OneSquareWidth = (HealMenuCursorXMax - HealMenuCursorXMin) / 24.0f;
-            injector::WriteMemory<float>(0x62D5D4, HealMenuBoxWidth / Screen.fHudScale, true);
-            injector::WriteMemory<float>(0x62D5D8, ((HealMenuCursorXMin + OneSquareWidth - 0.5f) * Screen.fHudScale) + 0.5f, true);
-            injector::WriteMemory<float>(0x62D5E4, ((HealMenuCursorXMax + OneSquareWidth - 0.5f) * Screen.fHudScale) + 0.5f, true);
-            injector::WriteMemory<float>(0x62D5DC, HealMenuCursorYMax - OneSquareWidth, true);
-            injector::WriteMemory<float>(0x62D5E0, HealMenuCursorYMin - OneSquareWidth, true);
+            // NOTE: Cursor was off by one small grid square in the OG game (fixed)
+            pattern = hook::pattern("D8 0D ? ? ? ? 89 44 24 ? D9 6C 24 ? DB 5C 24 ? 8B 44 24 ? 50"); // 4247B5
+            const float* ptr = injector::ReadMemory<float*>(pattern.get_first(2));
+            const float HealMenuBoxWidth = ptr[0]; // 26.087f
+            const float HealMenuCursorXMin = ptr[1]; // 0.35f
+            const float HealMenuCursorYMax = ptr[2]; // 0.87f
+            const float HealMenuCursorYMin = ptr[3]; // 0.635f
+            const float HealMenuCursorXMax = ptr[4]; // 0.58f
+            const float TinyBoxWidth = (HealMenuCursorXMax - HealMenuCursorXMin) / 24.0f; // 24 tiny boxes wide
+            injector::WriteMemory((uint32_t)&ptr[0], HealMenuBoxWidth / Screen.fHudScale, true);
+            injector::WriteMemory((uint32_t)&ptr[1], ((HealMenuCursorXMin + TinyBoxWidth - 0.5f) * Screen.fHudScale) + 0.5f, true);
+            injector::WriteMemory((uint32_t)&ptr[2], HealMenuCursorYMax - TinyBoxWidth, true);
+            injector::WriteMemory((uint32_t)&ptr[3], HealMenuCursorYMin - TinyBoxWidth, true);
+            injector::WriteMemory((uint32_t)&ptr[4], ((HealMenuCursorXMax + TinyBoxWidth - 0.5f) * Screen.fHudScale) + 0.5f, true);
         }
     }; injector::MakeInline<ResHook>(pattern.count(1).get(0).get<uintptr_t>(0), pattern.count(1).get(0).get<uintptr_t>(9));
 


### PR DESCRIPTION
PROBLEM:
-Open Inventory Menu with [I]. 
Hover mouse over top-left icon (book) - instead the second icon (watch) will be selected.
-Click on Jack to view Heal Menu. 
Hover mouse over left-most square in grid - instead the second square will be selected.
-Watch the Heart Rate Monitor at top-right of the screen. 
Right-most Line Paper texture disappears leaving ink line over black screen.

SOLUTION:
-Added/Modified calculations for cursor boxes in inventory and heal menu.
-Found unused black square in inventory menu. Covered the right-most Line Paper with it. However, the ink line was being drawn at the top layer (on top of the black box). Adjusted the ink line to be between the black box and the inventory.

TESTING:
I've played up to Innsmouth with no issues. Only tested on 16:9 monitor as that's all I have available.