### PR TITLE
SCPT: Vibration toggle in config

### DIFF
--- a/data/SplinterCellPandoraTomorrow.WidescreenFix/system/scripts/SplinterCellPandoraTomorrow.WidescreenFix.ini
+++ b/data/SplinterCellPandoraTomorrow.WidescreenFix/system/scripts/SplinterCellPandoraTomorrow.WidescreenFix.ini
@@ -1,7 +1,8 @@
 [MAIN]
 ResX = 0
 ResY = 0
-RawInputMouseForMenu = 1       // Enables raw input for mouse in menus
+RawInputMouseForMenu = 1       // Enables raw input for mouse in menus.
+Vibration = 1                  // Enables controller vibration.
 FMVWidescreenMode = 1          // Cutscenes and movies will be fullscreen.
 HudWidescreenMode = 2          // Makes certain hud elements offset to screen edges.
 OpsatWidescreenMode = 0        // Makes opsat overlay widescreen by stretching it is center part.

--- a/source/SplinterCellPandoraTomorrow.WidescreenFix/ComVars.ixx
+++ b/source/SplinterCellPandoraTomorrow.WidescreenFix/ComVars.ixx
@@ -49,6 +49,7 @@ export bool bPressStartToContinue = false;
 export bool bSkipPressStartToContinue = false;
 export HWND hGameWindow = NULL;
 export bool bIsWindowed = false;
+export bool bVibration = false;
 export int32_t RawMouseCursorX = 0;
 export int32_t RawMouseCursorY = 0;
 export int32_t RawMouseDeltaX = 0;

--- a/source/SplinterCellPandoraTomorrow.WidescreenFix/WinDrv.ixx
+++ b/source/SplinterCellPandoraTomorrow.WidescreenFix/WinDrv.ixx
@@ -12,7 +12,7 @@ namespace UWindowsViewport
     SafetyHookInline shUpdateRumble = {};
     void __fastcall UpdateRumble(void* UWindowsViewport, void* edx, float vibrateStrength, float shakeStrength)
     {
-        if (!XidiSendVibration)
+        if (!XidiSendVibration || !bVibration)
             return;
 
         constexpr float RUMBLE_MIN_STRENGTH = 0.0f;

--- a/source/SplinterCellPandoraTomorrow.WidescreenFix/dllmain.cpp
+++ b/source/SplinterCellPandoraTomorrow.WidescreenFix/dllmain.cpp
@@ -27,6 +27,7 @@ void Init()
     gColor.RGBA = iniReader.ReadInteger("BONUS", "GogglesLightColor", 0);
     bSkipIntro = iniReader.ReadInteger("MAIN", "SkipIntro", 0) != 0;
     bSkipPressStartToContinue = iniReader.ReadInteger("MAIN", "SkipPressStartToContinue", 0) != 0;
+    bVibration = iniReader.ReadInteger("MAIN", "Vibration", 0) != 0;
 
     if (!Screen.Width || !Screen.Height)
         std::tie(Screen.Width, Screen.Height) = GetDesktopRes();


### PR DESCRIPTION
Added config option to toggle controller vibration.

I've intentionally left `UseRumble=True` in `SplinterCell2.ini` regardless of the vibration setting so that the `ERumble` object is always created at level start. This ensures that if vibration is later enabled, the object already exists when loading an old save that initially had vibration off.