### PR TITLE
SC1: Add 16:10 (Steam Deck) support for Enhanced's widescreen HUD

### DIFF
--- a/source/SplinterCell.WidescreenFix/D3DDrv.ixx
+++ b/source/SplinterCell.WidescreenFix/D3DDrv.ixx
@@ -57,7 +57,7 @@ int __fastcall UD3DRenderDeviceSetRes(void* UD3DRenderDevice, void* edx, void* U
             UIntOverrides::Register(L"IntProperty Echelon.EchelonGameInfo.bWidescreenMode", +[]() -> int
             {
                 // Dynamic check if user switches resolution while game is open
-                return (Screen.fAspectRatio >= (16.0f / 9.0f)) ? 1 : 0;
+                return (Screen.fAspectRatio >= (16.0f / 10.0f)) ? 1 : 0;
             });
             bWidescreenOverrideRegistered = true;
         }


### PR DESCRIPTION
This change only affects the Enhanced version of the game. When using Enhanced, certain HUD changes are applied only for wide enough aspect ratios, and 16:10 is now supported.