### PR TITLE
SC1: Exclude Xbox pause menu from Xidi Menu profile

### DIFF
--- a/source/SplinterCell.WidescreenFix/Xidi.ixx
+++ b/source/SplinterCell.WidescreenFix/Xidi.ixx
@@ -23,6 +23,10 @@ export void InitXidi()
         {
             XidiRegisterProfileCallback([]() -> const wchar_t*
             {
+                auto EchelonMainHUDState = UObject::GetState(L"EchelonMainHUD");
+                if (bIsEnhanced && EchelonMainHUDState == L"s_GameMenu")
+                    return L"EnhancedMain";
+
                 bool bIsMainMenu = UObject::GetState(L"EPCConsole") == L"UWindow";
                 if (bIsMainMenu)
                     return L"Menu";
@@ -33,7 +37,6 @@ export void InitXidi()
                 if (bIsEnhanced)
                     return L"EnhancedMain";
 
-                auto EchelonMainHUDState = UObject::GetState(L"EchelonMainHUD");
                 if (EchelonMainHUDState == L"MainHUD" || EchelonMainHUDState == L"s_Slavery")
                 {
                     auto EPlayerControllerState = UObject::GetState(L"EPlayerController");


### PR DESCRIPTION
This change only applies to the Enhanced version of the game. In Enhanced, pressing the Start button on a controller opens the Xbox pause menu instead of the PC pause menu, so we shouldn’t switch to the Xidi Menu profile.