### PR TITLE
SC1: Use fHudAspectRatioConstraint to calculate Enhanced's widescreen mode

### DIFF
--- a/source/SplinterCell.WidescreenFix/D3DDrv.ixx
+++ b/source/SplinterCell.WidescreenFix/D3DDrv.ixx
@@ -70,7 +70,9 @@ int __fastcall UD3DRenderDeviceSetRes(void* UD3DRenderDevice, void* edx, void* U
             UIntOverrides::Register(L"IntProperty Echelon.EchelonGameInfo.bWidescreenMode", +[]() -> int
             {
                 // Dynamic check if user switches resolution while game is open
-                return (Screen.fAspectRatio >= (16.0f / 10.0f)) ? 1 : 0;
+                return (Screen.fHudAspectRatioConstraint.has_value() ? 
+                        Screen.fHudAspectRatioConstraint.value() >= (3.0f / 2.0f) :
+                        Screen.fAspectRatio >= (3.0f / 2.0f)) ? 1 : 0;
             });
             bWidescreenOverrideRegistered = true;
         }


### PR DESCRIPTION
This change only affects the Enhanced version of the game. It now uses `fHudAspectRatioConstraint` to determine the Enhanced widescreen variable, since someone can be on a widescreen aspect ratio with a 4:3 HUD, in which case we want to disable the toggle. The minimum allowed aspect ratio for Enhanced's “widescreen” HUD is 3:2.