### PR TITLE
GTA SA: Safer widescreen resolutions unlock patch

### DIFF
--- a/source/GTASA.WidescreenFix/dllmain.cpp
+++ b/source/GTASA.WidescreenFix/dllmain.cpp
@@ -692,9 +692,16 @@ void InstallSCMDrawingFixes()
 void InstallAspectRatioFixes()
 {
     // Unlock resolutions
-    injector::MakeJMP(0x745B5B, (void*)0x745BCB, true);
-    injector::WriteMemory<BYTE>(0x745BD1, 0x7D, true);
-    injector::WriteMemory<BYTE>(0x745BD9, 0x7C, true);
+    // Advanced Display Options
+    injector::MakeNOP(0x745B71, 6); // Skip width check
+    injector::MakeNOP(0x745B81, 6); // Skip height check
+    injector::WriteMemory<BYTE>(0x745B96, 0xEB, true); // Skip AR check
+    injector::MakeNOP(0x745BFC, 2); // Skip VRAM check
+
+    // Resolution selection dialog
+    injector::MakeNOP(0x74596C, 6); // Skip width check
+    injector::MakeNOP(0x74597A, 6); // Skip height check
+    injector::WriteMemory<BYTE>(0x7459D0, 0xEB, true); // Skip AR check
 
     // Proportional coronas
     injector::MakeNOP(0x6FB2C9, 4);


### PR DESCRIPTION
Same as a new fix in SilentPatch: https://github.com/CookiePLMonster/SilentPatch/commit/3fbb6957b9aa788cd89f2c80af92ca14b5510e27

The old code jumped through the initializations of `ecx` and `edx` and could cause false-negatives in the VRAM check code. The new code leaves everything as-is and only neutralizes the branches. VRAM check has now also been removed, and the multi-monitor resolution selection dialog received the same fixes.

I have **not** tested this in wsfix, but I have tested those fixes in SP both with and without the "old" SP approach. They don't seem to conflict, so any combination of new/old SP + new/old wsfix should be fine.