### PR TITLE
SC1: Update Xidi profiles for Enhanced

### DIFF
--- a/source/SplinterCell.WidescreenFix/Xidi.ixx
+++ b/source/SplinterCell.WidescreenFix/Xidi.ixx
@@ -23,20 +23,17 @@ export void InitXidi()
         {
             XidiRegisterProfileCallback([]() -> const wchar_t*
             {
-                auto EchelonMainHUDState = UObject::GetState(L"EchelonMainHUD");
-                if (IsEnhanced() && EchelonMainHUDState == L"s_GameMenu")
-                    return L"EnhancedMain";
-
                 if (bPlayingVideo || bPressStartToContinue)
                     return L"Video";
+
+                if (IsEnhanced())
+                    return L"EnhancedMain";
 
                 bool bIsMainMenu = UObject::GetState(L"EPCConsole") == L"UWindow";
                 if (bIsMainMenu)
                     return L"Menu";
 
-                if (IsEnhanced())
-                    return L"EnhancedMain";
-
+                auto EchelonMainHUDState = UObject::GetState(L"EchelonMainHUD");
                 if (EchelonMainHUDState == L"MainHUD" || EchelonMainHUDState == L"s_Slavery")
                 {
                     auto EPlayerControllerState = UObject::GetState(L"EPlayerController");


### PR DESCRIPTION
Enhanced patch now natively supports controllers in the PC menus, requiring only a switch to the `CustomMapper:Video` profile during cinematics or loading screens.