### PR TITLE
True Crime NYC - Fix speed being too fast

### DIFF
--- a/source/TrueCrimeNewYorkCity.WidescreenFix/Speedhack.ixx
+++ b/source/TrueCrimeNewYorkCity.WidescreenFix/Speedhack.ixx
@@ -287,8 +287,8 @@ export void InitSpeedhack()
     MH_CreateHook(realGetTickCount64, GetTickCount64_Hook, (void**)&realGetTickCount64);
     MH_CreateHook(realTimeGetTime, timeGetTime_Hook, (void**)&realTimeGetTime);
     MH_CreateHook(realQPC, QPC_Hook, (void**)&realQPC);
-    MH_CreateHook(realNtQuerySystemTime, NtQuerySystemTime_Hook, (void**)&realNtQuerySystemTime);
-    MH_CreateHook(realNtQueryPerformanceCounter, NtQueryPerformanceCounter_Hook, (void**)&realNtQueryPerformanceCounter);
+    //MH_CreateHook(realNtQuerySystemTime, NtQuerySystemTime_Hook, (void**)&realNtQuerySystemTime);
+    //MH_CreateHook(realNtQueryPerformanceCounter, NtQueryPerformanceCounter_Hook, (void**)&realNtQueryPerformanceCounter);
 
     MH_EnableHook(MH_ALL_HOOKS);
 


### PR DESCRIPTION
I couldn't figure out how to hook the NT stuff without using minhook, don't know if you'd want to push this because of that. But this seems to be what was making it go too fast at least.
Tested with both .exe's and it worked.