### PR TITLE
tcnyc speedhack: replace hook and reanchor

### DIFF
--- a/source/TrueCrimeNewYorkCity.WidescreenFix/Speedhack.ixx
+++ b/source/TrueCrimeNewYorkCity.WidescreenFix/Speedhack.ixx
@@ -11,7 +11,7 @@ static volatile uint32_t* bPause = nullptr;
 static volatile uint32_t* bCutscene = nullptr;
 static volatile uint32_t* bLoading = nullptr;
 
-static bool versionDetected = false;
+static bool isRU{ false };
 static bool versionDetected = false;
 struct SimpleLock
 {


### PR DESCRIPTION
Other .exe wouldn't start unless I replaced the hook pattern with that, I only know of 2 .exe's. So it should be fine. Besides filesize only difference seems to be this text at the bottom:
This one wouldnt start
<img width="731" height="36" alt="eng" src="https://github.com/user-attachments/assets/7d072ba8-2d89-45a2-93a0-e94aaec8476f" />
This one would
<img width="1055" height="36" alt="ru" src="https://github.com/user-attachments/assets/80e3f02a-4beb-4fd0-9dec-e423e4633120" />

It wasn't working well with the DGVoodoo d3d8 wrapper (small hitches during loading screens) but adding this thing to reanchor fixed it. This hitching didn't happen using your d3d8 wrapper. The reason to want to use DGVoodoo over yours though is for MSAAx8 and it fixes bug weapon textures being too bright by setting it to use higher DirectX api, can limit FPS as well.
d3d9:
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/29d0117d-9c7c-4c5c-aac9-36e5920b0bcb" />
d3d11:
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/3cc569c0-4390-4531-9121-967c326adbee" />

I removed pause lines because with the older version of widescreen fix, limiting FPS to 60 in that would cause map to become 30FPS which no longer happens it stays at 60, so it should stay at half speed now. Or else it will be too fast.
