### PR TITLE
SC1: Add 60 fps cap + v-sync, 16x anisotropic filtering to dgVoodoo.conf

### DIFF
--- a/data/SplinterCell.WidescreenFix/system/dgVoodoo.conf
+++ b/data/SplinterCell.WidescreenFix/system/dgVoodoo.conf
@@ -117,7 +117,7 @@ ColorSpace                           = appdriven
 FreeMouse                            = false
 WindowedAttributes                   = 
 FullscreenAttributes                 = 
-FPSLimit                             = 0
+FPSLimit                             = 60
 Environment                          = 
 SystemHookFlags                      = 
 
@@ -192,7 +192,7 @@ DisableAndPassThru                  = false
 
 VideoCard                           = geforce_ti_4800
 VRAM                                = 4096
-Filtering                           = appdriven
+Filtering                           = 16
 Mipmapping                          = appdriven
 KeepFilterIfPointSampled            = false
 Resolution                          = unforced
@@ -203,7 +203,7 @@ DisableAltEnterToToggleScreenMode   = true
 
 Bilinear2DOperations                = false
 PhongShadingWhenPossible            = false
-ForceVerticalSync                   = false
+ForceVerticalSync                   = true
 dgVoodooWatermark                   = false
 FastVideoMemoryAccess               = false
 


### PR DESCRIPTION
Added a 60 FPS cap to SC1 to prevent AI pathing and physics [issues](https://youtu.be/X3tuerrwhnw) similar to SCCT/SCDA. Also enabled 16x anisotropic filtering as a visual improvement.