### PR TITLE
GTA SA: Fix LockonFire scaling & co-op in-car crosshair (ellipse before now circular)

### DIFF
--- a/source/GTASA.WidescreenFix/dllmain.cpp
+++ b/source/GTASA.WidescreenFix/dllmain.cpp
@@ -1533,22 +1533,25 @@ void Install2dSpriteFixes()
     injector::MakeCALL(0x590480, DrawLoadingBarHook);
 
     // Make rocket launcher and hydra lockons circular rather than an ellipse (clippy95)
-    uintptr_t m_dwLockOnWidth[] = { 0x742E52,
-                         0x742E63,
-                         0x742EE0,
-                         0x742EF1,
-                         0x742FFF,
-                         0x743010,
-                         0x7430A4,
-                         0x7430B5,
+    uintptr_t m_dwLockOnWidth[] = { 0x742E50,
+                         0x742E61,
+                         0x742EDE,
+                         0x742EEF,
+                         0x742FFD,
+                         0x74300E,
+                         0x7430A2,
+                         0x7430B3,
     };
 
     for (int i = 0; i < sizeof(m_dwLockOnWidth) / sizeof(const void*); i++)
     {
         if (m_dwLockOnWidth[i] != NULL)
             // 0x858BA4 points to 20.f
-            injector::WriteMemory<uintptr_t>(m_dwLockOnWidth[i], 0x858BA4, true);
+            injector::WriteMemory<uintptr_t>(m_dwLockOnWidth[i] + 2, 0x858BA4, true);
     }
+
+    // Make co-op in-car crosshair circular rather than an ellipse (clippy95)
+    injector::WriteMemory<uint8_t>(0x00743BCD, 0x34, true); // multiply by a4 rather than a3
 
 }
 


### PR DESCRIPTION
Should [solve this issue](https://github.com/ThirteenAG/WidescreenFixesPack/issues/2027)
1. Fix Lockon scaling
before
![gta_sa_gIAPDBZlzp](https://github.com/user-attachments/assets/9efb8c54-bd3c-4446-a24e-cf91bf262cd5)
after
![gta_sa_nbs07mC28A](https://github.com/user-attachments/assets/71efe1b2-b815-4d5d-a5af-50e7b1ce9ada)

-----------

2. Fix co-op in-car crosshair scaling
before (was also effected in 4:3 but much more severe in widescreen)

![gta_sa_l7iZQiPc12](https://github.com/user-attachments/assets/15c21a22-e889-4845-869e-c5e5a51939ee)


after

![gta_sa_z6TzP6InsJ](https://github.com/user-attachments/assets/9f0914b3-e8fa-42a9-8873-0a70fbd459c5)

