### PR TITLE
RE6: DisplayMode buffer overflow crash/UB fix

### DIFF
--- a/data/ResidentEvil6.FusionFix/scripts/ResidentEvil6.FusionFix.ini
+++ b/data/ResidentEvil6.FusionFix/scripts/ResidentEvil6.FusionFix.ini
@@ -7,3 +7,7 @@ DisableDBNOEffects = 0           ; Disables the screen effects that occur when y
 DisableObjectiveIndicator = 0    ; Hides the objective marker
 CutsceneLetterbox = 1            ; Cinematic top/bottom bars during cutscenes
 CutscenePillarbox = 1            ; Black bars on the left and right during cutscenes to enforce 16:9 aspect ratio
+DisplayModeFix = 1               ; Fixes overflow UB on monitors with > 256 display modes
+DisplayModeFixResX = 1920        ; Horizontal resolution to use for the display mode fix
+DisplayModeFixResY = 1080        ; Vertical resolution to use for the display mode fix
+

--- a/data/ResidentEvil6.FusionFix/scripts/ResidentEvil6.FusionFix.ini
+++ b/data/ResidentEvil6.FusionFix/scripts/ResidentEvil6.FusionFix.ini
@@ -7,7 +7,7 @@ DisableDBNOEffects = 0           ; Disables the screen effects that occur when y
 DisableObjectiveIndicator = 0    ; Hides the objective marker
 CutsceneLetterbox = 1            ; Cinematic top/bottom bars during cutscenes
 CutscenePillarbox = 1            ; Black bars on the left and right during cutscenes to enforce 16:9 aspect ratio
-DisplayModeFix = 1               ; Fixes overflow UB on monitors with > 256 display modes
+DisplayModeFix = 0               ; Fixes overflow UB on monitors with > 256 display modes (crash on stratup)
 DisplayModeFixResX = 1920        ; Horizontal resolution to use for the display mode fix
 DisplayModeFixResY = 1080        ; Vertical resolution to use for the display mode fix
 

--- a/source/ResidentEvil6.FusionFix/dllmain.cpp
+++ b/source/ResidentEvil6.FusionFix/dllmain.cpp
@@ -14,6 +14,231 @@ int32_t ResY = 0;
 
 std::map<uintptr_t, uintptr_t> addrTbl;
 
+namespace DisplayModeFix { 
+    typedef IDirect3D9* (WINAPI* PFN_Direct3DCreate9)(
+        UINT SDKVersion
+    );
+
+    typedef UINT(STDMETHODCALLTYPE* PFN_GetAdapterModeCount)(
+        IDirect3D9* This,
+        UINT Adapter,
+        D3DFORMAT Format
+    );
+
+    typedef HRESULT(STDMETHODCALLTYPE* PFN_EnumAdapterModes)(
+        IDirect3D9* This,
+        UINT Adapter,
+        D3DFORMAT Format,
+        UINT Mode,
+        D3DDISPLAYMODE* pMode
+    );
+
+    struct Config
+    {
+        uint32_t width;
+        uint32_t height;
+        bool enabled;
+    } resConfig;
+
+    static PFN_GetAdapterModeCount g_RealGetAdapterModeCount = nullptr;
+    static PFN_EnumAdapterModes g_RealEnumAdapterModes = nullptr;
+
+    constexpr DWORD IDX_GetAdapterModeCount = 6;
+    constexpr DWORD IDX_EnumAdapterModes = 7;
+    
+    IDirect3D9 *g_pDirect3D9Instance = nullptr;
+    SafetyHookInline g_inlineSafetyHook{};
+
+    std::vector<D3DDISPLAYMODE> g_vDisplayModes{};   // Filtered display modes
+
+    UINT STDMETHODCALLTYPE Hook_GetAdapterModeCount(
+        IDirect3D9* This,
+        UINT Adapter,
+        D3DFORMAT Format
+    ) {
+        if (nullptr == g_RealGetAdapterModeCount) {
+            return 0;
+        }
+
+        UINT uModeCount = g_RealGetAdapterModeCount(This, Adapter, Format);
+
+        // game only queries for D3DFMT_X8R8G8B8 modes, see disasm below
+        if (D3DFMT_X8R8G8B8 != Format) {
+            MessageBoxA(
+                nullptr,
+                "Unexpected format passed to GetAdapterModeCount hook. Expected D3DFMT_X8R8G8B8.",
+                "RE6 Crash Fix",
+                MB_ICONERROR
+            );
+            ExitProcess(EXIT_FAILURE);
+        }
+
+        g_vDisplayModes.clear();
+        for (UINT i = 0; i < uModeCount; i++) {
+            if (g_vDisplayModes.size() >= 256) {
+                break;
+            }
+
+            D3DDISPLAYMODE displayMode{};
+            HRESULT hr = g_RealEnumAdapterModes(
+                This,
+                Adapter,
+                Format,
+                i,
+                &displayMode
+            );
+            if (FAILED(hr)) {
+                continue;
+            }
+
+            if (
+                displayMode.Width != resConfig.width
+                ||
+                displayMode.Height != resConfig.height
+            ) {
+                continue;
+            }
+
+            g_vDisplayModes.push_back(displayMode);
+        }
+
+        uModeCount = static_cast<UINT>(g_vDisplayModes.size());
+
+        return uModeCount;
+    }
+
+    HRESULT STDMETHODCALLTYPE Hook_EnumAdapterModes(
+        IDirect3D9* This,
+        UINT Adapter,
+        D3DFORMAT Format,
+        UINT Mode,
+        D3DDISPLAYMODE* pMode
+    ) {
+        if (nullptr == g_RealEnumAdapterModes) {
+            return E_FAIL;
+        }
+
+        if (nullptr == pMode) {
+            return D3DERR_INVALIDCALL;
+        }
+
+        if (0 == g_vDisplayModes.size()) {
+            return D3DERR_INVALIDCALL;
+        }
+
+        if (Mode >= g_vDisplayModes.size()) {
+            return D3DERR_INVALIDCALL;
+        }
+
+        *pMode = g_vDisplayModes[Mode];
+        return D3D_OK;
+    }
+
+    bool HookD3D9Object(
+    _In_ IDirect3D9* pD3D9
+    ) {
+        if (nullptr == pD3D9) {
+            return false;
+        }
+
+        void*** pppVtable = reinterpret_cast<void***>(pD3D9);
+        if (nullptr == pppVtable || nullptr == *pppVtable) {
+            return false;
+        }
+
+        void** ppVtable = *pppVtable;
+
+        DWORD dwOldProtect = 0;
+        if (!VirtualProtect(
+            &ppVtable[IDX_GetAdapterModeCount],
+            (sizeof(void*) * 2),
+            PAGE_EXECUTE_READWRITE,
+            &dwOldProtect
+        )) {
+            return false;
+        }
+
+        if (
+            ppVtable[IDX_GetAdapterModeCount] == reinterpret_cast<void*>(&Hook_GetAdapterModeCount)
+            ||
+            ppVtable[IDX_EnumAdapterModes] == reinterpret_cast<void*>(&Hook_EnumAdapterModes)
+        ) {
+            // already hooked, bozo
+            return true;
+        }
+
+        g_RealGetAdapterModeCount = reinterpret_cast<PFN_GetAdapterModeCount>(
+            ppVtable[IDX_GetAdapterModeCount]
+        );
+
+        g_RealEnumAdapterModes = reinterpret_cast<PFN_EnumAdapterModes>(
+            ppVtable[IDX_EnumAdapterModes]
+        );
+
+        ppVtable[IDX_GetAdapterModeCount] =
+            reinterpret_cast<void*>(&Hook_GetAdapterModeCount);
+
+        ppVtable[IDX_EnumAdapterModes] =
+            reinterpret_cast<void*>(&Hook_EnumAdapterModes);
+
+        DWORD dwDummy = 0;
+        VirtualProtect(
+            &ppVtable[IDX_GetAdapterModeCount],
+            (sizeof(void*) * 2),
+            dwOldProtect,
+            &dwDummy
+        );
+
+        return true;
+    }
+
+    IDirect3D9* WINAPI Hooked_Direct3DCreate9(
+        UINT SDKVersion
+    ) {
+        g_pDirect3D9Instance = g_inlineSafetyHook.stdcall<IDirect3D9*>(SDKVersion);
+        
+        if (!HookD3D9Object(g_pDirect3D9Instance)) {
+            MessageBoxA(
+                nullptr,
+                "Failed to hook IDirect3D9 object.",
+                "RE6 Crash Fix",
+                MB_ICONERROR
+            );
+        }
+
+        return g_pDirect3D9Instance;
+    }
+
+    bool AutoInitConfig(void) {
+        DEVMODEA devMode;
+        devMode.dmSize = sizeof(DEVMODEA);
+
+        if (!EnumDisplaySettingsA(
+            nullptr,
+            ENUM_CURRENT_SETTINGS,
+            &devMode
+        )) {
+            // fallback to 1080p
+            resConfig.width = 1920;
+            resConfig.height = 1080;
+        }
+
+        resConfig.width = devMode.dmPelsWidth;
+        resConfig.height = devMode.dmPelsHeight;
+
+        return true;
+    }
+    bool Install(void) {
+        // 67E14B20 = Direct3DCreate9
+        g_inlineSafetyHook = safetyhook::create_inline(
+            reinterpret_cast<void*>(0x67E14B20),
+            reinterpret_cast<void*>(&Hooked_Direct3DCreate9)
+        );
+
+        return g_inlineSafetyHook.enabled();
+    }
+}
+
 void FillAddressTable()
 {
     addrTbl[0x17CF454] = (uintptr_t)*hook::get_pattern<uint32_t>("8B 0D ? ? ? ? E8 ? ? ? ? 84 C0 75 0E", 2);
@@ -751,6 +976,22 @@ void Init()
     auto bAutoclicker = iniReader.ReadInteger("MAIN", "Autoclicker", 0) != 0;
     static auto bCutsceneLetterbox = iniReader.ReadInteger("MAIN", "CutsceneLetterbox", 1) != 0;
     static auto bCutscenePillarbox = iniReader.ReadInteger("MAIN", "CutscenePillarbox", 1) != 0;
+    DisplayModeFix::resConfig.enabled = iniReader.ReadInteger("MAIN", "DisplayModeFix", 1) != 0;
+
+    if (DisplayModeFix::resConfig.enabled)
+    {
+        DisplayModeFix::resConfig.width = iniReader.ReadInteger("MAIN", "DisplayModeFixResX", 0);
+        DisplayModeFix::resConfig.height = iniReader.ReadInteger("MAIN", "DisplayModeFixResY", 0);
+
+        if (0 == DisplayModeFix::resConfig.width || 0 == DisplayModeFix::resConfig.height)
+        {
+            DisplayModeFix::AutoInitConfig();
+        }
+        
+        if (!DisplayModeFix::Install()) {
+            MessageBoxA(nullptr, "Failed to install display mode fix!", "Error", MB_ICONERROR);
+        }
+    }
 
     FillAddressTable();
 

--- a/source/ResidentEvil6.FusionFix/dllmain.cpp
+++ b/source/ResidentEvil6.FusionFix/dllmain.cpp
@@ -229,9 +229,18 @@ namespace DisplayModeFix {
         return true;
     }
     bool Install(void) {
-        // 67E14B20 = Direct3DCreate9
+        HMODULE hD3D9 = GetModuleHandleA("d3d9.dll");
+        if (nullptr == hD3D9) {
+            return false;
+        }
+
+        FARPROC pfnDirect3DCreate9 = GetProcAddress(hD3D9, "Direct3DCreate9");
+        if (nullptr == pfnDirect3DCreate9) {
+            return false;
+        }
+        
         g_inlineSafetyHook = safetyhook::create_inline(
-            reinterpret_cast<void*>(0x67E14B20),
+            reinterpret_cast<void*>(pfnDirect3DCreate9),
             reinterpret_cast<void*>(&Hooked_Direct3DCreate9)
         );
 


### PR DESCRIPTION
RE6 suffers from OOB r/w when enumerating display modes on monitors with `>= 256` display modes, which can lead to startup crashes and/or other UB stuff.
The applied fix clamps the enumerated display modes to `256`, and filters out modes that don't match user-specified resolution.

I'm attempting to merge [this fix - RE6CrashFix](https://github.com/x0reaxeax/RE6CrashFix) into FusionFix, since the two projects don't seem to be working together [RE6CrashFix - Issue #1](https://github.com/x0reaxeax/RE6CrashFix/issues/1), I'm not sure tho whether the fix is acceptable in terms of how FusionFix is written, meaning that I use inline `SafetyHook` to hook `Direct3D9Instance` [dllmain.cpp:233](https://github.com/x0reaxeax/WidescreenFixesPack/blob/1ee7043d5e0cf0a452bd3e3ada4a69a2a7813f2e/source/ResidentEvil6.FusionFix/dllmain.cpp#L233) to grab the created `IDirect3D9` object, and then hook the vtable entries for `IDirect3D9::GetAdapterModeCount` and `IDirect3D9::EnumAdapterModes`.
I didn't touch the `addrTbl`, and I'm not sure whether that's a problem. The fix is separated into its own namespace.

There are 3 new additions to the `INI` file:

- `DisplayModeFix = 0               ; Fixes overflow UB on monitors with > 256 display modes (crash on stratup)`
- `DisplayModeFixResX = 1920        ; Horizontal resolution to use for the display mode fix`
- `DisplayModeFixResY = 1080        ; Vertical resolution to use for the display mode fix`

The `DisplayModeFix` is disabled by default, as it limits available resolutions in the game's graphic settings. 
The game seems to be running fine with it enabled, no crashes, and all related R/Ws are within bounds. I tested on 3 different systems.
Thanks in advance!