### PR TITLE
SC1: Animated texture fix

### DIFF
--- a/source/SplinterCell.WidescreenFix/Engine.ixx
+++ b/source/SplinterCell.WidescreenFix/Engine.ixx
@@ -151,6 +151,35 @@ namespace UCanvas
     }
 }
 
+// Animated texture fix
+namespace UTexture
+{
+    constexpr uintptr_t kMaxFrameRateOff = 0xA8;
+    constexpr uintptr_t kAccumulatorOff  = 0xAC;
+
+    constexpr float kStep = 1.0f / 30.0f;
+
+    SafetyHookInline shTick = {};
+    void __fastcall Tick(void* self, void* edx, float deltaSeconds)
+    {
+        const float maxFrameRate = *reinterpret_cast<float*>(reinterpret_cast<uintptr_t>(self) + kMaxFrameRateOff);
+
+        if (maxFrameRate != 0.0f || !(deltaSeconds > 0.0f))
+            return shTick.unsafe_fastcall(self, edx, deltaSeconds);
+
+        float& accumulator = *reinterpret_cast<float*>(reinterpret_cast<uintptr_t>(self) + kAccumulatorOff);
+        accumulator += deltaSeconds;
+
+        if (accumulator >= kStep)
+        {
+            accumulator -= kStep;
+            if (accumulator > kStep)
+                accumulator = kStep;
+            shTick.unsafe_fastcall(self, edx, deltaSeconds);
+        }
+    }
+}
+
 #if _DEBUG
 SafetyHookInline shFindAxisName = {};
 float* __fastcall FindAxisName(void* UInput, void* edx, void* AActor, const wchar_t* a3)
@@ -309,6 +338,8 @@ export void InitEngine()
     UGameEngine::shTick = safetyhook::create_inline(GetProcAddress(GetModuleHandle(L"Engine"), "?Tick@UGameEngine@@UAEXM@Z"), UGameEngine::Tick);
 
     UCanvas::shSetClip = safetyhook::create_inline(GetProcAddress(GetModuleHandle(L"Engine"), "?SetClip@UCanvas@@UAEXMM@Z"), UCanvas::SetClip);
+
+    UTexture::shTick = safetyhook::create_inline(GetProcAddress(GetModuleHandle(L"Engine"), "?Tick@UTexture@@UAEXM@Z"), UTexture::Tick);
 
     pattern = find_module_pattern(GetModuleHandle(L"Engine"), "8B 85 40 01 00 00 6A 00 8B 48 18");
     static auto UGameEngineLoadGameHook = safetyhook::create_mid(pattern.get_first(), [](SafetyHookContext& regs)


### PR DESCRIPTION
Animated textures were previously tied to the frame rate, causing them to play faster on higher FPS


https://github.com/user-attachments/assets/202a9450-49fa-4d5d-bfa1-7b30ebe30d1c

https://github.com/user-attachments/assets/1b094bb1-b78a-4264-8fd0-b256a6a26967


