### PR TITLE
SC1: Option to increase shadow buffer resolution

### DIFF
--- a/data/SplinterCell.WidescreenFix/system/scripts/SplinterCell.WidescreenFix.ini
+++ b/data/SplinterCell.WidescreenFix/system/scripts/SplinterCell.WidescreenFix.ini
@@ -2,6 +2,7 @@
 ResX = 0
 ResY = 0
 ForceShadowBufferMode = 1            // Forces buffered shadows.
+ShadowBufferResolution = 0   		 // The game uses 2048 by default. Increasing the value renders shadows at a higher resolution.  If set to 1, ResX will be used instead (clamped to 4096 at higher resolutions to avoid crashes with dgVoodoo 2).
 RawInputMouse = 1.0                  // Enables raw mouse input. Also acts as a sensitivity multiplier.
 RawInputMouseRawData = 0             // Uses raw mouse input without OS acceleration or speed adjustments (0 = disabled, 1 = enabled).
 FMVWidescreenMode = 1                // Expands FMVs to display in fullscreen at widescreen resolutions instead of 4:3.

--- a/source/SplinterCell.WidescreenFix/ComVars.ixx
+++ b/source/SplinterCell.WidescreenFix/ComVars.ixx
@@ -25,6 +25,7 @@ export struct Screen
     float fWidescreenHudOffset;
     int nHudWidescreenMode;
     uint32_t nFMVWidescreenMode;
+    uint32_t nShadowBufferResolution;
     float fRawInputMouse;
     bool bRawInputMouseRawData;
     bool bDeferredInput;

--- a/source/SplinterCell.WidescreenFix/D3DDrv.ixx
+++ b/source/SplinterCell.WidescreenFix/D3DDrv.ixx
@@ -106,6 +106,52 @@ int __fastcall UD3DRenderDeviceSetRes(void* UD3DRenderDevice, void* edx, void* U
 
 namespace UD3DRenderDevice
 {
+    SafetyHookInline shGetShadowBufferResolutionWidth = {};
+    int __fastcall GetShadowBufferResolutionWidth(void* self, void* edx)
+    {
+        int stock = shGetShadowBufferResolutionWidth.unsafe_fastcall<int>(self, edx);
+
+        if (Screen.nShadowBufferResolution <= 0 || stock <= 0)
+            return stock;
+
+        int raw;
+
+        if (Screen.nShadowBufferResolution == 1)
+            raw = Screen.Width;
+        else
+            raw = static_cast<int>(Screen.nShadowBufferResolution);
+
+        if (raw < stock)
+            raw = stock;
+
+        // Clamping to 4096x4096 for dgVoodoo 2 compatability for now
+        //return raw > 16384 ? 16384 : raw;
+        return raw > 4096 ? 4096 : raw;
+    }
+
+    SafetyHookInline shGetShadowBufferResolutionHeight = {};
+    int __fastcall GetShadowBufferResolutionHeight(void* self, void* edx)
+    {
+        int stock = shGetShadowBufferResolutionHeight.unsafe_fastcall<int>(self, edx);
+
+        if (Screen.nShadowBufferResolution <= 0 || stock <= 0)
+            return stock;
+
+        int raw;
+
+        if (Screen.nShadowBufferResolution == 1)
+            raw = Screen.Width;
+        else
+            raw = static_cast<int>(Screen.nShadowBufferResolution); // Default game used nShadowBufferResolution / 2 for height
+        
+        if (raw < stock)
+            raw = stock;
+
+        // Clamping to 4096x4096 for dgVoodoo 2 compatability for now
+        //return raw > 16384 ? 16384 : raw;
+        return raw > 4096 ? 4096 : raw;
+    }
+
     SafetyHookInline shDisplayVideo = {};
     void __fastcall DisplayVideo(void* UD3DRenderDevice, void* edx, void* UCanvas, void* a3)
     {
@@ -340,6 +386,9 @@ export void InitD3DDrv()
     });
 
     UD3DRenderDevice::shDisplayVideo = safetyhook::create_inline(GetProcAddress(GetModuleHandle(L"D3DDrv"), "?DisplayVideo@UD3DRenderDevice@@UAEXPAVUCanvas@@PAX@Z"), UD3DRenderDevice::DisplayVideo);
+
+    UD3DRenderDevice::shGetShadowBufferResolutionWidth = safetyhook::create_inline(GetProcAddress(GetModuleHandle(L"D3DDrv"), "?GetShadowBufferResolutionWidth@UD3DRenderDevice@@UAEHXZ"), UD3DRenderDevice::GetShadowBufferResolutionWidth);
+    UD3DRenderDevice::shGetShadowBufferResolutionHeight = safetyhook::create_inline(GetProcAddress(GetModuleHandle(L"D3DDrv"), "?GetShadowBufferResolutionHeight@UD3DRenderDevice@@UAEHXZ"), UD3DRenderDevice::GetShadowBufferResolutionHeight);
 
     pattern = hook::module_pattern(GetModuleHandle(L"D3DDrv"), "8B 10 FF 92 ? ? ? ? 8B 86 14 5D 00 00");
     static auto EndSceneHook = safetyhook::create_mid(pattern.get_first(), [](SafetyHookContext& regs)

--- a/source/SplinterCell.WidescreenFix/dllmain.cpp
+++ b/source/SplinterCell.WidescreenFix/dllmain.cpp
@@ -28,6 +28,7 @@ void Init()
     bSkipPressStartToContinue = iniReader.ReadInteger("MAIN", "SkipPressStartToContinue", 0) != 0;
     bRestoreCutsceneFOV = iniReader.ReadInteger("MAIN", "RestoreCutsceneFOV", 0) != 0;
     Screen.nCutsceneBorders = iniReader.ReadInteger("MAIN", "CutsceneBorders", 0);
+    Screen.nShadowBufferResolution = iniReader.ReadInteger("MAIN", "ShadowBufferResolution", 0);
 
     if (!Screen.Width || !Screen.Height)
         std::tie(Screen.Width, Screen.Height) = GetDesktopRes();


### PR DESCRIPTION
Currently clamped to 4096x4096 to prevent crashes in dgVoodoo 2. Shadow filtering is currently missing when the resolution is increased.

<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/3d4244d8-1913-4489-82c3-b6dd79f92120"/>

<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/a49e383f-96d1-4a20-9fdd-4410ad9cec24"/>