### PR TITLE
SC1: Fix vision mode scaling at high resolutions

### DIFF
--- a/source/SplinterCell.WidescreenFix/D3DDrv.ixx
+++ b/source/SplinterCell.WidescreenFix/D3DDrv.ixx
@@ -408,4 +408,20 @@ export void InitD3DDrv()
             }
         }
     });
+
+    // Fix night vision grain scaling at high resolutions
+    pattern = hook::module_pattern(GetModuleHandle(L"D3DDrv"), "D9 5C 24 14 FF 15 ? ? ? ? D9 5C 24 10");
+    if (!pattern.empty())
+    {
+        static auto NightVisionGrainHook = safetyhook::create_mid(pattern.get_first(4), [](SafetyHookContext& regs)
+        {
+            uint32_t height = *(uint32_t*)(regs.esp + 0xCD0);
+            if (height == 0)
+                return;
+
+            float scale = 480.0f / static_cast<float>(height);
+            *(float*)(regs.esp + 0x14) *= scale;
+            *(float*)(regs.esp + 0x28) *= scale;
+        });
+    }
 }

--- a/source/SplinterCell.WidescreenFix/Engine.ixx
+++ b/source/SplinterCell.WidescreenFix/Engine.ixx
@@ -314,6 +314,33 @@ export void InitEngine()
             *(uint32_t*)(regs.esp + 0x2C) = 0;
     });
 
+    // Fix thermal vision grain scaling at high resolutions
+    static auto ThermalGrainScaleHeight = [](SafetyHookContext& regs)
+    {
+        regs.eax = 480; // V tile count becomes 480 / noiseTexHeight
+    };
+    static auto ThermalGrainScaleWidth = [](SafetyHookContext& regs)
+    {
+        uint32_t height = *(uint32_t*)(regs.edx + 0x80); // UViewport screen height
+        if (height == 0)
+            return;
+        uint32_t eff = (uint32_t)((uint64_t)regs.eax * 480ull / height); // width * 480 / height
+        regs.eax = eff < 1u ? 1u : eff;
+    };
+
+    pattern = hook::module_pattern(GetModuleHandle(L"Engine"), "8B 82 80 00 00 00 99 F7 F9 8D 4C 24 30");
+    size_t nThermalGrain = pattern.count_hint(2).size();
+    if (nThermalGrain >= 1)
+    {
+        static auto ThermalGrainHeightHook0 = safetyhook::create_mid(pattern.get(0).get<void>(0x06), ThermalGrainScaleHeight);
+        static auto ThermalGrainWidthHook0  = safetyhook::create_mid(pattern.get(0).get<void>(0x3C), ThermalGrainScaleWidth);
+    }
+    if (nThermalGrain >= 2)
+    {
+        static auto ThermalGrainHeightHook1 = safetyhook::create_mid(pattern.get(1).get<void>(0x06), ThermalGrainScaleHeight);
+        static auto ThermalGrainWidthHook1  = safetyhook::create_mid(pattern.get(1).get<void>(0x3C), ThermalGrainScaleWidth);
+    }
+
     if (bSkipIntro)
     {
         pattern = find_module_pattern(GetModuleHandle(L"Engine"), "75 ? A1 ? ? ? ? 85 C0 75 ? 68 00 00 80 3F");


### PR DESCRIPTION
The grain texture would shrink as resolution increased, making the grain look weaker at higher resolutions.

<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/84117e9b-c9c3-4515-86ed-8e8d7a99a4d1"/>

<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/eaa0c6c7-ee3f-4528-b9e9-640e8990217c"/>
