### PR TITLE
SCPT: Fix vision mode scaling at high resolutions + increase thermal vision resolution

### DIFF
--- a/data/SplinterCell.WidescreenFix/system/scripts/SplinterCell.WidescreenFix.ini
+++ b/data/SplinterCell.WidescreenFix/system/scripts/SplinterCell.WidescreenFix.ini
@@ -8,11 +8,11 @@ RawInputMouseRawData = 0             // Uses raw mouse input without OS accelera
 FMVWidescreenMode = 1                // Expands FMVs to display in fullscreen at widescreen resolutions instead of 4:3.
 HudWidescreenMode = 2                // Offsets certain HUD elements to the screen edges.
 HudAspectRatioConstraint = Auto      // Constrains the HUD to an aspect ratio. Use Auto, 16:9, 21:9, or a custom ratio.
+GrainScale = 1.0                     // Controls night vision and thermal vision grain scaling at high resolutions. 1.0 = fully scaled to 640x480 baseline (recommended), 0.0 = unscaled original behavior.
 SkipIntro = 0                        // Skips the intro logos.
 SkipPressStartToContinue = 0         // Skips the "Press Fire to Continue" prompt.
 RestoreCutsceneFOV = 1               // Restores the original FOV values during in-engine cutscenes.
 CutsceneBorders = 2                  // Set to 0 for the default behavior (borders are always displayed), 1 to disable borders, and 2 to make border size depend on aspect ratio.
-GrainScale = 1.0                     // Controls night vision and thermal vision grain scaling at high resolutions. 1.0 = fully scaled to 640x480 baseline (recommended), 0.0 = unscaled original behavior.
 
 [MISC]
 FPSLimit = 60                        // Recommended: 60, increasing the frame rate can lead to issues with AI pathfinding and physics objects.

--- a/data/SplinterCellPandoraTomorrow.WidescreenFix/system/scripts/SplinterCellPandoraTomorrow.WidescreenFix.ini
+++ b/data/SplinterCellPandoraTomorrow.WidescreenFix/system/scripts/SplinterCellPandoraTomorrow.WidescreenFix.ini
@@ -9,6 +9,7 @@ OpsatWidescreenMode = 0              // Stretches the background OPSAT texture t
 ScopeWidescreenMode = 0              // Offsets the sniper scope textures to widescreen.
 HudAspectRatioConstraint = Auto      // Constrains the HUD to an aspect ratio. Use Auto, 16:9, 21:9, or a custom ratio.
 PostProcessFixedScale = 1            // The game uses 512 by default. Increasing the value renders night vision at a higher resolution. If set to 1, ResX will be used instead.
+GrainScale = 1.0                     // Controls night vision and thermal vision grain scaling at high resolutions. 1.0 = fully scaled to 640x480 baseline (recommended), 0.0 = unscaled original behavior.
 ShadowMapResolution = 1              // The game uses 256 and above by default. Increasing the value renders shadows at a higher resolution.  If set to 1, ResX will be used instead (clamped to 2048 at higher resolutions to avoid crashes and instability).
 ReflectionsResolution = 1            // The game uses 256 by default. Increasing the value renders reflections at a higher resolution.  If set to 1, ResX will be used instead (clamped to 2048 at higher resolutions to avoid crashes and instability).
 LightDistanceMultiplier = 8.0        // Multiplies the distance dynamic lights and shadows remain active. 1.0 keeps the game default.

--- a/source/SplinterCell.WidescreenFix/dllmain.cpp
+++ b/source/SplinterCell.WidescreenFix/dllmain.cpp
@@ -17,20 +17,20 @@ void Init()
     CIniReader iniReader("");
     Screen.Width = iniReader.ReadInteger("MAIN", "ResX", 0);
     Screen.Height = iniReader.ReadInteger("MAIN", "ResY", 0);
+    Screen.nShadowBufferResolution = iniReader.ReadInteger("MAIN", "ShadowBufferResolution", 0);
     Screen.bDeferredInput = iniReader.ReadInteger("MAIN", "DeferredInput", 1) != 0;
     Screen.fRawInputMouse = std::clamp(iniReader.ReadFloat("MAIN", "RawInputMouse", 1.0f), 0.0f, 5.0f);
     Screen.bRawInputMouseRawData = iniReader.ReadInteger("MAIN", "RawInputMouseRawData", 0) != 0;
     Screen.nFMVWidescreenMode = iniReader.ReadInteger("MAIN", "FMVWidescreenMode", 1);
     Screen.nHudWidescreenMode = iniReader.ReadInteger("MAIN", "HudWidescreenMode", 2);
     Screen.fHudAspectRatioConstraint = ParseWidescreenHudOffset(iniReader.ReadString("MAIN", "HudAspectRatioConstraint", ""));
+    Screen.fGrainScale = std::clamp(iniReader.ReadFloat("MAIN", "GrainScale", 1.0f), 0.0f, 1.0f);
     auto nFPSLimit = iniReader.ReadInteger("MISC", "FPSLimit", 1000);
     bSkipIntro = iniReader.ReadInteger("MAIN", "SkipIntro", 0) != 0;
     bSkipPressStartToContinue = iniReader.ReadInteger("MAIN", "SkipPressStartToContinue", 0) != 0;
     bRestoreCutsceneFOV = iniReader.ReadInteger("MAIN", "RestoreCutsceneFOV", 0) != 0;
     Screen.nCutsceneBorders = iniReader.ReadInteger("MAIN", "CutsceneBorders", 0);
-    Screen.fGrainScale = std::clamp(iniReader.ReadFloat("MAIN", "GrainScale", 1.0f), 0.0f, 1.0f);
-    Screen.nShadowBufferResolution = iniReader.ReadInteger("MAIN", "ShadowBufferResolution", 0);
-
+    
     if (!Screen.Width || !Screen.Height)
         std::tie(Screen.Width, Screen.Height) = GetDesktopRes();
 

--- a/source/SplinterCellPandoraTomorrow.WidescreenFix/ComVars.ixx
+++ b/source/SplinterCellPandoraTomorrow.WidescreenFix/ComVars.ixx
@@ -37,6 +37,7 @@ export struct Screen
     bool bRawInputMouseRawData;
     bool bDeferredInput;
     int nCutsceneBorders;
+    float fGrainScale;
 } Screen;
 
 export union FColor

--- a/source/SplinterCellPandoraTomorrow.WidescreenFix/D3DDrv.ixx
+++ b/source/SplinterCellPandoraTomorrow.WidescreenFix/D3DDrv.ixx
@@ -633,5 +633,26 @@ export void InitD3DDrv()
         }
     });
 
+    // Fix night vision grain scaling at high resolutions
+    pattern = find_module_pattern(GetModuleHandle(L"D3DDrv"), "F3 0F 5E C8 F3 0F 11 8D 18 FA FF FF FF D0 66 0F 6E 8D 14 FA FF FF 0F 5B C9 66 0F 6E C0 0F 5B C0 F3 0F 5E C8 F3 0F 11 8D 04 FA FF FF");
+    if (!pattern.empty())
+    {
+        static auto NightVisionGrainHook = safetyhook::create_mid(pattern.get_first(0x2C), [](SafetyHookContext& regs)
+            {
+                if (Screen.fGrainScale == 0.0f)
+                    return;
+
+                float* pGrainScaleU = reinterpret_cast<float*>(regs.ebp - 0x5E8);
+                float* pGrainScaleV = reinterpret_cast<float*>(regs.ebp - 0x5FC);
+                float  renderWidth = static_cast<float>(*reinterpret_cast<int32_t*>(regs.ebp - 0x5F0));
+                float  renderHeight = static_cast<float>(*reinterpret_cast<int32_t*>(regs.ebp - 0x5EC));
+                if (renderWidth > 0.0f && renderHeight > 0.0f)
+                {
+                    *pGrainScaleU *= 1.0f + (640.0f / renderWidth  - 1.0f) * Screen.fGrainScale;
+                    *pGrainScaleV *= 1.0f + (480.0f / renderHeight - 1.0f) * Screen.fGrainScale;
+                }
+            });
+    }
+
     InitShaders();
 }

--- a/source/SplinterCellPandoraTomorrow.WidescreenFix/Engine.ixx
+++ b/source/SplinterCellPandoraTomorrow.WidescreenFix/Engine.ixx
@@ -417,6 +417,11 @@ export void InitEngine()
             injector::WriteMemory(pattern2.get(i).get<uint32_t>(1), Screen.nPostProcessFixedScale, true);
             injector::WriteMemory(pattern2.get(i).get<uint32_t>(6), Screen.nPostProcessFixedScale, true);
         }
+
+        // Thermal vision uses a separate render target size so it bypasses the main fix, apply PostProcessFixedScale here as well
+        auto thermalRT = find_module_pattern(GetModuleHandle(L"Engine"), "8B 0C 85 ? ? ? ? 8B 75 10");
+        if (!thermalRT.empty())
+            injector::WriteMemory<uint32_t>(*thermalRT.get_first<uintptr_t>(3), Screen.nPostProcessFixedScale, true);
     }
 
     if (gColor.RGBA)
@@ -534,4 +539,23 @@ export void InitEngine()
     AActor::shPostLoad = safetyhook::create_inline(
         GetProcAddress(GetModuleHandle(L"Engine"), "?PostLoad@AActor@@UAEXXZ"),
         AActor::PostLoad);
+
+    // Fix thermal vision grain scaling at high resolutions
+    pattern = find_module_pattern(GetModuleHandle(L"Engine"), "8B 46 04 8B 80 84 00 00 00 99 F7 F9 66 0F 6E C0");
+    if (!pattern.empty())
+    {
+        static auto ThermalGrainHeightHook = safetyhook::create_mid(pattern.get_first(9), [](SafetyHookContext& regs)
+        {
+            regs.eax = static_cast<uint32_t>((float)regs.eax + (480.0f - (float)regs.eax) * Screen.fGrainScale);
+        });
+    }
+
+    pattern = find_module_pattern(GetModuleHandle(L"Engine"), "8B 46 04 8B 80 80 00 00 00 99 F7 F9 8D 8D 74 FE FF FF");
+    if (!pattern.empty())
+    {
+        static auto ThermalGrainWidthHook = safetyhook::create_mid(pattern.get_first(9), [](SafetyHookContext& regs)
+        {
+            regs.eax = static_cast<uint32_t>((float)regs.eax + (640.0f - (float)regs.eax) * Screen.fGrainScale);
+        });
+    }
 }

--- a/source/SplinterCellPandoraTomorrow.WidescreenFix/Engine.ixx
+++ b/source/SplinterCellPandoraTomorrow.WidescreenFix/Engine.ixx
@@ -421,7 +421,19 @@ export void InitEngine()
         // Thermal vision uses a separate render target size so it bypasses the main fix, apply PostProcessFixedScale here as well
         auto thermalRT = find_module_pattern(GetModuleHandle(L"Engine"), "8B 0C 85 ? ? ? ? 8B 75 10");
         if (!thermalRT.empty())
-            injector::WriteMemory<uint32_t>(*thermalRT.get_first<uintptr_t>(3), Screen.nPostProcessFixedScale, true);
+        {
+            // Override all thermal RT presets
+            uintptr_t thermalSceneSizes = *thermalRT.get_first<uintptr_t>(3);
+            for (int i = 0; i < 3; i++)
+                injector::WriteMemory<uint32_t>(thermalSceneSizes + i * 4, Screen.nPostProcessFixedScale, true);
+        }
+    }
+
+    // Force thermal vision to use quality preset 2 (1024px pyramid)
+    {
+        auto thermalDispatch = find_module_pattern(GetModuleHandle(L"Engine"), "FF B5 FC FB FF FF 56 53 6A 00 E8");
+        if (!thermalDispatch.empty())
+            injector::WriteMemory<uint8_t>(thermalDispatch.get_first(9), 2, true);
     }
 
     if (gColor.RGBA)

--- a/source/SplinterCellPandoraTomorrow.WidescreenFix/dllmain.cpp
+++ b/source/SplinterCellPandoraTomorrow.WidescreenFix/dllmain.cpp
@@ -25,6 +25,7 @@ void Init()
     Screen.bScopeWidescreenMode = iniReader.ReadInteger("MAIN", "ScopeWidescreenMode", 0) != 0;
     Screen.fHudAspectRatioConstraint = ParseWidescreenHudOffset(iniReader.ReadString("MAIN", "HudAspectRatioConstraint", ""));
     Screen.nPostProcessFixedScale = iniReader.ReadInteger("MAIN", "PostProcessFixedScale", 1);
+    Screen.fGrainScale = std::clamp(iniReader.ReadFloat("MAIN", "GrainScale", 1.0f), 0.0f, 1.0f);
     Screen.nShadowMapResolution = iniReader.ReadInteger("MAIN", "ShadowMapResolution", 1);
     Screen.nReflectionsResolution = iniReader.ReadInteger("MAIN", "ReflectionsResolution", 1);
     Screen.nBloomResolutionMultiplier = std::clamp(iniReader.ReadInteger("MAIN", "BloomResolutionMultiplier", 0), 0, 4);


### PR DESCRIPTION
The grain texture would shrink as resolution increased, making the grain look weaker at higher resolutions. Thermal Vision now increases its render resolution when using the `PostProcessFixedScale` setting, previously only Night Vision increased its render scale resolution.