### PR TITLE
SC1: Camera FPS fix

### DIFF
--- a/source/SplinterCell.WidescreenFix/Echelon.ixx
+++ b/source/SplinterCell.WidescreenFix/Echelon.ixx
@@ -79,10 +79,109 @@ namespace AETextureManager
     }
 }
 
+// EPlayerCam FPS fixes
+namespace AEPlayerCam
+{
+    // Above 30 FPS, ftol() rounds speed * DeltaTime down to 0, so DampFloat() never settles
+    constexpr float kStep     = 1.0f / 30.0f;
+    constexpr int   kMaxSteps = 8;
+
+    constexpr uintptr_t kHitRoll      = 0x1324;
+    constexpr uintptr_t kHitFadeOut   = 0x1328;
+    constexpr uintptr_t kShakeRoll    = 0x132c;
+    constexpr uintptr_t kShakeTarget  = 0x1330;
+    constexpr uintptr_t kShakeSpeed   = 0x1334;
+    constexpr uintptr_t kShakeFadeOut = 0x1338;
+    constexpr uintptr_t kTiltPitch    = 0x133c;
+    constexpr uintptr_t kTiltTarget   = 0x1340;
+    constexpr uintptr_t kTiltSpeed    = 0x1344;
+    constexpr uintptr_t kTiltFadeOut  = 0x1348;
+
+    constexpr uintptr_t kLevelOff     = 0x6c;
+    constexpr uintptr_t kDeltaTimeOff = 0x55c;
+
+    float accumulator = 0.0f;
+
+    SafetyHookInline shUpdateView = {};
+    void __fastcall UpdateView(void* cam, void* edx, int p1, int p2, int p3, int p4)
+    {
+        if (!cam)
+            return shUpdateView.unsafe_fastcall(cam, edx, p1, p2, p3, p4);
+
+        const auto base  = reinterpret_cast<uintptr_t>(cam);
+        const auto level = *reinterpret_cast<uintptr_t*>(base + kLevelOff);
+        if (!level)
+            return shUpdateView.unsafe_fastcall(cam, edx, p1, p2, p3, p4);
+
+        float& levelDt = *reinterpret_cast<float*>(level + kDeltaTimeOff);
+        const float realDt = levelDt;
+        if (!(realDt > 0.0f))
+            return shUpdateView.unsafe_fastcall(cam, edx, p1, p2, p3, p4);
+
+        accumulator += realDt;
+
+        if (accumulator < kStep)
+        {
+            // Stop speed updates but allow camera rotation
+            const int saved[10] = {
+                *reinterpret_cast<int*>(base + kHitRoll),
+                *reinterpret_cast<int*>(base + kHitFadeOut),
+                *reinterpret_cast<int*>(base + kShakeRoll),
+                *reinterpret_cast<int*>(base + kShakeTarget),
+                *reinterpret_cast<int*>(base + kShakeSpeed),
+                *reinterpret_cast<int*>(base + kShakeFadeOut),
+                *reinterpret_cast<int*>(base + kTiltPitch),
+                *reinterpret_cast<int*>(base + kTiltTarget),
+                *reinterpret_cast<int*>(base + kTiltSpeed),
+                *reinterpret_cast<int*>(base + kTiltFadeOut),
+            };
+
+            *reinterpret_cast<int*>(base + kHitFadeOut)   = 0;
+            *reinterpret_cast<int*>(base + kShakeSpeed)   = 0;
+            *reinterpret_cast<int*>(base + kShakeFadeOut) = 0;
+            *reinterpret_cast<int*>(base + kTiltSpeed)    = 0;
+            *reinterpret_cast<int*>(base + kTiltFadeOut)  = 0;
+
+            shUpdateView.unsafe_fastcall(cam, edx, p1, p2, p3, p4);
+
+            *reinterpret_cast<int*>(base + kHitRoll)      = saved[0];
+            *reinterpret_cast<int*>(base + kHitFadeOut)   = saved[1];
+            *reinterpret_cast<int*>(base + kShakeRoll)    = saved[2];
+            *reinterpret_cast<int*>(base + kShakeTarget)  = saved[3];
+            *reinterpret_cast<int*>(base + kShakeSpeed)   = saved[4];
+            *reinterpret_cast<int*>(base + kShakeFadeOut) = saved[5];
+            *reinterpret_cast<int*>(base + kTiltPitch)    = saved[6];
+            *reinterpret_cast<int*>(base + kTiltTarget)   = saved[7];
+            *reinterpret_cast<int*>(base + kTiltSpeed)    = saved[8];
+            *reinterpret_cast<int*>(base + kTiltFadeOut)  = saved[9];
+            return;
+        }
+
+        int steps = 0;
+        while (accumulator >= kStep)
+        {
+            accumulator -= kStep;
+            if (++steps >= kMaxSteps)
+            {
+                accumulator = 0.0f; // discard excess accumulated time to avoid stalls
+                break;
+            }
+        }
+
+        levelDt = kStep;
+        for (int i = 0; i < steps; ++i)
+            shUpdateView.unsafe_fastcall(cam, edx, p1, p2, p3, p4);
+        levelDt = realDt;
+    }
+}
+
 export void InitEchelon()
 {
     //EPlayerController additional state cache
     AEPlayerController::shTick = safetyhook::create_inline(GetProcAddress(GetModuleHandle(L"Echelon"), "?Tick@AEPlayerController@@UAEHMW4ELevelTick@@@Z"), AEPlayerController::Tick);
+
+    // EPlayerCam FPS fixes
+    AEPlayerCam::shUpdateView = safetyhook::create_inline(GetProcAddress(GetModuleHandle(L"Echelon"), "?UpdateView@AEPlayerCam@@QAEXVFRotator@@H@Z"), AEPlayerCam::UpdateView);
 
     // Letterboxing
     auto pattern = find_module_pattern(GetModuleHandle(L"Echelon"), "D9 1C 24 50 53 E8 ? ? ? ? 5F");
@@ -101,7 +200,7 @@ export void InitEchelon()
         curDrawTileManagerTextureIndex = regs.eax;
     });
 
-    // set player speed to max on game start
+    // Set player speed to max on game start
     if (!IsEnhanced())
     {
         UIntOverrides::Register(L"IntProperty Echelon.EchelonGameInfo.m_defautSpeed", +[]() -> int


### PR DESCRIPTION
Camera shake effects lasted longer and were more exaggerated at higher frame rates than intended when targeting 30 FPS

https://github.com/user-attachments/assets/b929f202-e053-41f0-bc6d-5b47ba496a00

https://github.com/user-attachments/assets/0daa3ab1-e28d-48a8-b19b-a52c1baedfc1

