### PR TITLE
SCPT: Fix analog bind

### DIFF
--- a/data/SplinterCellPandoraTomorrow.WidescreenFix/system/scripts/SplinterCellPandoraTomorrow.WidescreenFix.ini
+++ b/data/SplinterCellPandoraTomorrow.WidescreenFix/system/scripts/SplinterCellPandoraTomorrow.WidescreenFix.ini
@@ -55,7 +55,7 @@ JoyV=Axis aLookUp DeadZone=0.3
 JoyZ=Axis aTurn DeadZone=0.3
 JoyR=
 JoyU=
-AnalogUp=MoveForward
-AnalogDown=MoveBackward
-AnalogLeft=StrafeLeft
-AnalogRight=StrafeRight
+AnalogUp=AnalogUp
+AnalogDown=AnalogDown
+AnalogLeft=AnalogLeft
+AnalogRight=AnalogRight


### PR DESCRIPTION
SCPT was incorrectly mapping the analog movement bindings as:
```
AnalogUp=MoveForward
AnalogDown=MoveBackward
AnalogLeft=StrafeLeft
AnalogRight=StrafeRight
```
instead of the correct analog bindings:
```
AnalogUp=AnalogUp
AnalogDown=AnalogDown
AnalogLeft=AnalogLeft
AnalogRight=AnalogRight
```
`AnalogUp`, `AnalogDown`, `AnalogLeft`, and `AnalogRight` are triggered once the thumbstick reaches a 72% threshold and are meant for menu navigation. Binding them to movement caused the thumbstick to jump from 72% to 100% input instead of staying linear.