### PR TITLE
SC1: Vision grain FPS fixes

### DIFF
--- a/source/SplinterCell.WidescreenFix/ComVars.ixx
+++ b/source/SplinterCell.WidescreenFix/ComVars.ixx
@@ -243,6 +243,81 @@ struct UOverride
     }
 };
 
+// Night vision and thermal vision FPS fix. D3DDrv and Engine normally rebuild
+// the noise grain's random angle/UV transform every rendered frame, making the
+// grain animate faster at high FPS. Hold the random values at 30 Hz instead.
+export namespace VisionNoiseGrain
+{
+    constexpr double fStep = 1.0 / 30.0;
+
+    float(__cdecl* pAppFrand)() = nullptr;
+
+    // Resolve Core.dll's appFrand once, the fix is skipped when unavailable
+    bool Init()
+    {
+        if (!pAppFrand)
+            pAppFrand = (decltype(pAppFrand))GetProcAddress(GetModuleHandle(L"Core"), "?appFrand@@YAMXZ");
+        return pAppFrand != nullptr;
+    }
+
+    double NowSeconds()
+    {
+        static const double fFreq = []
+        {
+            LARGE_INTEGER liFreq;
+            QueryPerformanceFrequency(&liFreq);
+            return static_cast<double>(liFreq.QuadPart);
+        }();
+        LARGE_INTEGER liNow;
+        QueryPerformanceCounter(&liNow);
+        return static_cast<double>(liNow.QuadPart) / fFreq;
+    }
+
+    struct HeldCluster
+    {
+        float v[3] = {};
+        double fLast = -1.0;
+
+        void Refresh()
+        {
+            const double fNow = NowSeconds();
+            if (fLast >= 0.0)
+            {
+                const double fElapsed = fNow - fLast;
+                if (fElapsed < fStep)
+                    return;
+                // Advance in whole 30 Hz steps to keep the update rate exact
+                fLast += static_cast<double>(static_cast<int64_t>(fElapsed / fStep)) * fStep;
+            }
+            else
+                fLast = fNow;
+
+            v[0] = pAppFrand();
+            v[1] = pAppFrand();
+            v[2] = pAppFrand();
+        }
+    };
+
+    // 0/1 = night vision (pixel shader / fixed function path)
+    // 2/3 = thermal vision (pixel shader / low-end fallback path)
+    HeldCluster Clusters[4] = {};
+
+    // Refresh once per cluster, Index 0 is always the first appFrand() call
+    template <int Cluster, int Index>
+    float __cdecl HeldFrand()
+    {
+        if constexpr (Index == 0)
+            Clusters[Cluster].Refresh();
+        return Clusters[Cluster].v[Index];
+    }
+
+    void RedirectCallSite(uintptr_t addr, float(__cdecl* fn)())
+    {
+        injector::MakeCALL(addr, fn, true);
+        injector::MakeNOP(addr + 5, 1, true);
+    }
+}
+
 // Type aliases for current override kinds.
 export using UIntOverrides = UOverride<int(*)()>;
 export using UFloatOverrides = UOverride<float(*)()>;

--- a/source/SplinterCell.WidescreenFix/D3DDrv.ixx
+++ b/source/SplinterCell.WidescreenFix/D3DDrv.ixx
@@ -674,7 +674,7 @@ export void InitD3DDrv()
 
     UD3DRenderDevice::shGetShadowBufferResolutionWidth = safetyhook::create_inline(GetProcAddress(GetModuleHandle(L"D3DDrv"), "?GetShadowBufferResolutionWidth@UD3DRenderDevice@@UAEHXZ"), UD3DRenderDevice::GetShadowBufferResolutionWidth);
     UD3DRenderDevice::shGetShadowBufferResolutionHeight = safetyhook::create_inline(GetProcAddress(GetModuleHandle(L"D3DDrv"), "?GetShadowBufferResolutionHeight@UD3DRenderDevice@@UAEHXZ"), UD3DRenderDevice::GetShadowBufferResolutionHeight);
-    
+
     // High resolution Bink cutscene fix
     pPrepareTexture = (PrepareTexture_t)GetProcAddress(GetModuleHandle(L"D3DDrv"), "?PrepareTexture@UD3DRenderDevice@@QAEPAVUTexture@@HH@Z");
     if (HMODULE hBinkModule = GetModuleHandle(L"binkw32"))
@@ -757,11 +757,21 @@ export void InitD3DDrv()
         }
     });
 
-    // Fix night vision grain scaling at high resolutions
-    pattern = hook::module_pattern(GetModuleHandle(L"D3DDrv"), "D9 5C 24 14 FF 15 ? ? ? ? D9 5C 24 10");
+    // Fix night vision grain scaling and FPS-dependent noise animation
+    pattern = hook::module_pattern(GetModuleHandle(L"D3DDrv"), "D9 5C 24 14 FF 15 ? ? ? ? D9 5C 24 10 FF 15 ? ? ? ? D8 4C 24 14 D9 5C 24 24 FF 15 ? ? ? ? D8 4C 24 28");
     if (!pattern.empty())
     {
-        static auto NightVisionGrainHook = safetyhook::create_mid(pattern.get_first(4), [](SafetyHookContext& regs)
+        auto base = reinterpret_cast<uintptr_t>(pattern.get_first(0));
+
+        // Redirect call sites before creating the mid hook on the first call site
+        if (VisionNoiseGrain::Init())
+        {
+            VisionNoiseGrain::RedirectCallSite(base + 0x04, VisionNoiseGrain::HeldFrand<0, 0>); // rotation angle
+            VisionNoiseGrain::RedirectCallSite(base + 0x0E, VisionNoiseGrain::HeldFrand<0, 1>); // V offset
+            VisionNoiseGrain::RedirectCallSite(base + 0x1C, VisionNoiseGrain::HeldFrand<0, 2>); // U offset
+        }
+
+        static auto NightVisionGrainHook = safetyhook::create_mid(reinterpret_cast<void*>(base + 0x04), [](SafetyHookContext& regs)
         {
             if (Screen.fGrainScale == 0.0f)
                 return;
@@ -775,5 +785,15 @@ export void InitD3DDrv()
             *(float*)(regs.esp + 0x14) *= blendedScale;
             *(float*)(regs.esp + 0x28) *= blendedScale;
         });
+    }
+
+    // Fixed-function vision path for legacy GPUs like GeForce 2 (or EmulateGF2Mode=1 in SplinterCell.ini)
+    pattern = hook::module_pattern(GetModuleHandle(L"D3DDrv"), "D9 5C 24 28 FF 15 ? ? ? ? D9 5C 24 1C FF 15 ? ? ? ? D8 4C 24 28 D9 5C 24 7C FF 15 ? ? ? ? D8 4C 24 14");
+    if (!pattern.empty() && VisionNoiseGrain::Init())
+    {
+        auto base = reinterpret_cast<uintptr_t>(pattern.get_first(0));
+        VisionNoiseGrain::RedirectCallSite(base + 0x04, VisionNoiseGrain::HeldFrand<1, 0>); // rotation angle
+        VisionNoiseGrain::RedirectCallSite(base + 0x0E, VisionNoiseGrain::HeldFrand<1, 1>); // V offset
+        VisionNoiseGrain::RedirectCallSite(base + 0x1C, VisionNoiseGrain::HeldFrand<1, 2>); // U offset
     }
 }

--- a/source/SplinterCell.WidescreenFix/Engine.ixx
+++ b/source/SplinterCell.WidescreenFix/Engine.ixx
@@ -530,6 +530,29 @@ export void InitEngine()
         static auto ThermalGrainWidthHook1  = safetyhook::create_mid(pattern.get(1).get<void>(0x3C), ThermalGrainScaleWidth);
     }
 
+    // Thermal vision noise grain FPS fix
+    if (VisionNoiseGrain::Init())
+    {
+        // Noise grain TexMatrix random rotation (appFrand angle)
+        auto patternAngle = hook::module_pattern(GetModuleHandle(L"Engine"), "89 4A 4C FF 15 ? ? ? ? A1");
+        // Noise grain TexMatrix random UV offset (appFrand V/U)
+        auto patternUV = hook::module_pattern(GetModuleHandle(L"Engine"), "D9 5C 24 28 FF 15 ? ? ? ? D8 4C 24 28 51 D9 1C 24 FF 15 ? ? ? ?");
+
+        static constexpr float(__cdecl* kAngleFns[2])() = { VisionNoiseGrain::HeldFrand<2, 0>, VisionNoiseGrain::HeldFrand<3, 0> };
+        static constexpr float(__cdecl* kVFns[2])()     = { VisionNoiseGrain::HeldFrand<2, 1>, VisionNoiseGrain::HeldFrand<3, 1> };
+        static constexpr float(__cdecl* kUFns[2])()     = { VisionNoiseGrain::HeldFrand<2, 2>, VisionNoiseGrain::HeldFrand<3, 2> };
+
+        size_t nAngle = patternAngle.count_hint(2).size();
+        size_t nUV = patternUV.count_hint(2).size();
+        size_t nClusters = nAngle < nUV ? nAngle : nUV;
+        for (size_t i = 0; i < nClusters && i < 2; ++i)
+        {
+            VisionNoiseGrain::RedirectCallSite(reinterpret_cast<uintptr_t>(patternAngle.get(i).get<void>(0x03)), kAngleFns[i]); // rotation angle
+            VisionNoiseGrain::RedirectCallSite(reinterpret_cast<uintptr_t>(patternUV.get(i).get<void>(0x04)), kVFns[i]);        // V offset
+            VisionNoiseGrain::RedirectCallSite(reinterpret_cast<uintptr_t>(patternUV.get(i).get<void>(0x12)), kUFns[i]);        // U offset
+        }
+    }
+
     if (bSkipIntro)
     {
         pattern = find_module_pattern(GetModuleHandle(L"Engine"), "75 ? A1 ? ? ? ? 85 C0 75 ? 68 00 00 80 3F");


### PR DESCRIPTION
The vision grain was previously framerate-dependent, causing the animation speed to increase at higher FPS. It now updates at a fixed 30 Hz rate, matching the original 30 FPS behavior.