### PR TITLE
SA: Make the AR unlock fix safer

### DIFF
--- a/source/GTASA.WidescreenFix/Legacy.ixx
+++ b/source/GTASA.WidescreenFix/Legacy.ixx
@@ -699,13 +699,19 @@ void InstallAspectRatioFixes()
     // Advanced Display Options
     injector::MakeNOP(0x745B71, 6); // Skip width check
     injector::MakeNOP(0x745B81, 6); // Skip height check
-    injector::WriteMemory<BYTE>(0x745B96, 0xEB, true); // Skip AR check
+    if (injector::ReadMemory<BYTE>(0x745B96) == 0x7Bu) // SA-MP stomps over this entire block of code
+    {
+        injector::WriteMemory<BYTE>(0x745B96, 0xEB, true); // Skip AR check
+    }
     injector::MakeNOP(0x745BFC, 2); // Skip VRAM check
 
     // Resolution selection dialog
     injector::MakeNOP(0x74596C, 6); // Skip width check
     injector::MakeNOP(0x74597A, 6); // Skip height check
-    injector::WriteMemory<BYTE>(0x7459D0, 0xEB, true); // Skip AR check
+    if (injector::ReadMemory<BYTE>(0x7459D0) == 0x7Bu) // SA-MP stomps over this entire block of code
+    {
+        injector::WriteMemory<BYTE>(0x7459D0, 0xEB, true); // Skip AR check
+    }
 
     // Proportional coronas
     injector::MakeNOP(0x6FB2C9, 4);

--- a/source/GTASA.WidescreenFix/Main.ixx
+++ b/source/GTASA.WidescreenFix/Main.ixx
@@ -40,13 +40,19 @@ public:
             // Advanced Display Options
             injector::MakeNOP(0x745B71, 6); // Skip width check
             injector::MakeNOP(0x745B81, 6); // Skip height check
-            injector::WriteMemory<BYTE>(0x745B96, 0xEB, true); // Skip AR check
+            if (injector::ReadMemory<BYTE>(0x745B96) == 0x7Bu) // SA-MP stomps over this entire block of code
+            {
+                injector::WriteMemory<BYTE>(0x745B96, 0xEB, true); // Skip AR check
+            }
             injector::MakeNOP(0x745BFC, 2); // Skip VRAM check
 
             // Resolution selection dialog
             injector::MakeNOP(0x74596C, 6); // Skip width check
             injector::MakeNOP(0x74597A, 6); // Skip height check
-            injector::WriteMemory<BYTE>(0x7459D0, 0xEB, true); // Skip AR check
+            if (injector::ReadMemory<BYTE>(0x7459D0) == 0x7Bu) // SA-MP stomps over this entire block of code
+            {
+                injector::WriteMemory<BYTE>(0x7459D0, 0xEB, true); // Skip AR check
+            }
 
             // default res
             auto [x, y] = GetDesktopRes();


### PR DESCRIPTION
See https://github.com/CookiePLMonster/SilentPatch/issues/416

Port of a SP hotfix - in this case it's easy enough to just account for what SA-MP is doing to the function (nopping the entire area) and move on.