### PR TITLE
Fix SCDA audio when game drive is omitted by Gear

### DIFF
--- a/source/SplinterCellDoubleAgent.WidescreenFix/dllmain.cpp
+++ b/source/SplinterCellDoubleAgent.WidescreenFix/dllmain.cpp
@@ -192,6 +192,57 @@ void Init()
     //}, hook::pattern("89 85 D8 61 00 00").count_hint(1).empty(), 0x1100);
 }
 
+// Ensure Gear registers the drive containing the game when its 10-prefix limit is reached.
+void InitGear()
+{
+    static std::string gameDrive = GetExeModulePath().root_path().string();
+
+    if (gameDrive.size() != 3 || gameDrive[1] != ':' ||
+        (gameDrive[2] != '\\' && gameDrive[2] != '/'))
+    {
+        return;
+    }
+
+    gameDrive[2] = '\\';
+
+    auto pattern = hook::module_pattern(
+        GetModuleHandle(L"gear_RD"),
+        "8D 9E A4 02 00 00 89 5D FC C7 45 F8 34 04 00 00"
+    );
+
+    static auto GearDrivePrefixHook =
+        safetyhook::create_mid(pattern.get_first(), [](SafetyHookContext& regs)
+    {
+        auto* device = reinterpret_cast<uint8_t*>(regs.esi);
+        auto* prefixCount = reinterpret_cast<uint32_t*>(device + 0x14);
+        auto* prefixes = reinterpret_cast<const char**>(device + 0x18);
+
+        if (*prefixCount == 0 || *prefixCount > 10)
+        {
+            return;
+        }
+
+        for (uint32_t i = 0; i < *prefixCount; ++i)
+        {
+            if (prefixes[i] != nullptr &&
+                _stricmp(prefixes[i], gameDrive.c_str()) == 0)
+            {
+                return;
+            }
+        }
+
+        if (*prefixCount < 10)
+        {
+            prefixes[*prefixCount] = gameDrive.c_str();
+            ++(*prefixCount);
+        }
+        else
+        {
+            prefixes[9] = gameDrive.c_str();
+        }
+    });
+}
+
 CEXP void InitializeASI()
 {
     std::call_once(CallbackHandler::flag, []()
@@ -200,6 +251,7 @@ CEXP void InitializeASI()
         CallbackHandler::RegisterCallback(L"Window.dll", InitWindow);
         CallbackHandler::RegisterCallback(L"Engine.dll", InitEngine);
         CallbackHandler::RegisterCallback(L"D3DDrv.dll", InitD3DDrv);
+        CallbackHandler::RegisterCallback(L"gear_RD.dll", InitGear);
         CallbackHandler::RegisterCallback(L"EchelonMenus.dll", InitEchelonMenus);
         CallbackHandler::RegisterCallback(L"Echelon.dll", InitEchelon);
         CallbackHandler::RegisterCallback(L"Core.dll", InitCore);


### PR DESCRIPTION
## Summary

Fixes missing interactive audio in Splinter Cell: Double Agent when the game is installed on a drive that Gear does not register in its asynchronous filesystem device.

## Root cause

Gear::AsynchPlatformSpecific stores a maximum of 10 path prefixes.

One slot is used by the UNC prefix (`\\`), leaving only nine drive-root entries. On systems with many mounted fixed drives, the drive containing SplinterCell4.exe can therefore be omitted.

When the game resolves a sound project such as Echelon.SP0 to an omitted drive, Gear::DeviceInterface::Match() cannot associate the path with AsynchPlatformSpecific. SearchForDevice() returns null before filesystem I/O occurs, causing the sound project initialization to fail.

## Fix

When gear_RD.dll initializes, ensure that the drive containing SplinterCell4.exe is present in AsynchPlatformSpecific's prefix list.

If the drive is already registered, nothing is changed. If the 10-entry list is full, the final drive-prefix entry is replaced with the game's drive.

## Validation

Tested with SCDA installed on X:\  on a system where Gear's original prefix list stopped before X:\.

- Original Steam launch: interactive audio missing
- Manually replacing Q:\ with X:\ in Gear's prefix table: audio restored
- Patched Widescreen Fix build: audio restored
- Clean rebuild and Steam retest: audio working